### PR TITLE
changed DIV and lcd off register behaviour to reset internal counters, trigger ly==lyc irq earlier 

### DIFF
--- a/timer.v
+++ b/timer.v
@@ -45,9 +45,14 @@ module timer (
 // clk_div[8] = 8khz
 // clk_div[9] = 4khz
 
+wire resetdiv = cpu_sel && cpu_wr && (cpu_addr == 2'b00); //resetdiv also resets internal counter
+
 reg [9:0] clk_div;
-always @(posedge clk)
-	clk_div <= clk_div + 10'd1;
+always @(posedge clk or posedge resetdiv)
+	if(resetdiv)
+	  clk_div <= 10'd6;
+	else
+	  clk_div <= clk_div + 10'd1;
 
 reg [7:0] div;
 reg [7:0] tma;


### PR DESCRIPTION
LY==LYC was triggered to late (when LY was actually LYC+1) which in turn disabled the Duck Tales background rendering in-game. It still isn't 100% correct (the lasers are not drawn correctly in Parodius) but could be due to another timing issue.

The internal counter for the DIV and TIMA registers weren't reset when resetting DIV, so the first DIV tick was incorrect.

When disabling the Gameboy lcd (using the lcdon bit in the LCDC register) the v_cnt and h_cnt counters should be reset and stopped being incremented (and LY accordingly). 
This change enabled a few more games to go in-game (e.g. Super Mario Land 2 and Gargoyle's Quest) and fixed the boss select screen in Mega Man 1.

When using the lite version I noticed a few video de-syncs that weren't noticeable when using the full version, I assume it is because the lcd.v shift-register is waiting for a constant stream of pixels while the Gameboy can shut down the lcd arbitrarily.