### PR TITLE
Video: STAT FF41$ mode should be 0 when lcd off

### DIFF
--- a/video.v
+++ b/video.v
@@ -435,6 +435,7 @@ wire bg_tile_obj_rd = (!vblank) && (!hblank) && (h_cnt[2:1] == 2'b11);
 // Mode 10:  oam
 // Mode 11:  oam and vram
 assign mode = 
+   !lcdc_on?2'b00:
 	vblank?2'b01:
 	oam?2'b10:
 	hblank?2'b00:


### PR DESCRIPTION
Small but important change, fixes probably a lot of deadlocked games (e.g.: all the levels are finally playable for super mario land 2)