### PR TITLE
T80: resume after halt even if IME is disabled, fixed 3 instructions

### DIFF
--- a/t80/T80.vhd
+++ b/t80/T80.vhd
@@ -1105,6 +1105,8 @@ begin
 								IntCycle <= '1';
 								IntE_FF1 <= '0';
 								IntE_FF2 <= '0';
+							elsif (Halt_FF = '1' and INT_s = '1' and Mode = 3) then
+								Halt_FF <= '0';
 							end if;
 						else
 							MCycle <= std_logic_vector(unsigned(MCycle) + 1);

--- a/t80/T80.vhd
+++ b/t80/T80.vhd
@@ -151,7 +151,6 @@ architecture rtl of T80 is
 	-- Help Registers
 	signal TmpAddr              : std_logic_vector(15 downto 0);        -- Temporary address register
 	signal TmpAddr2             : std_logic_vector(15 downto 0);        -- Temporary address register
-	signal TmpAddr3             : std_logic_vector(15 downto 0);        -- Temporary address register
 	signal IR                   : std_logic_vector(7 downto 0);         -- Instruction register
 	signal ISet                 : std_logic_vector(1 downto 0);         -- Instruction set selector
 	signal RegBusA_r            : std_logic_vector(15 downto 0);
@@ -359,6 +358,8 @@ begin
 		ALU_Q;
 
 	process (RESET_n, CLK_n)
+	variable temp_c : unsigned(8 downto 0);
+	variable temp_h : unsigned(4 downto 0);
 	begin
 		if RESET_n = '0' then
 			PC <= (others => '0');  -- Program Counter
@@ -404,20 +405,22 @@ begin
 
 			MCycles <= MCycles_d;
 			
-			if LDHLSP = '1' and TState = 1 then
-					   TmpAddr <= std_logic_vector(SP xor unsigned(Save_Mux) xor unsigned(TmpAddr2)); 
-						F(Flag_Z) <= '0';	
-						F(Flag_N) <= '0';
-						F(Flag_H) <= TmpAddr(4);
-						F(Flag_C) <= TmpAddr(8);
-			end if;
-			
-			if ADDSPdd = '1' and TState = 4 then
-				TmpAddr3 <= std_logic_vector(SP xor unsigned(Save_Mux) xor unsigned(TmpAddr)); 
+			if LDHLSP = '1' and MCycle = "011" and TState = 1 then
+			   temp_c := unsigned('0'&SP(7 downto 0))+unsigned('0'&Save_Mux);
+				temp_h := unsigned('0'&SP(3 downto 0))+unsigned('0'&Save_Mux(3 downto 0));
 				F(Flag_Z) <= '0';	
 				F(Flag_N) <= '0';
-				F(Flag_H) <= TmpAddr3(4);
-				F(Flag_C) <= TmpAddr3(8);
+				F(Flag_H) <= temp_h(4);
+				F(Flag_C) <= temp_c(8);
+			end if;
+			
+			if ADDSPdd = '1' and TState = 1 then
+			   temp_c := unsigned('0'&SP(7 downto 0))+unsigned('0'&Save_Mux);
+				temp_h := unsigned('0'&SP(3 downto 0))+unsigned('0'&Save_Mux(3 downto 0));
+				F(Flag_Z) <= '0';	
+				F(Flag_N) <= '0';
+				F(Flag_H) <= temp_h(4);
+				F(Flag_C) <= temp_c(8);
 			end if;
 
       if Mode = 3 then

--- a/t80/T80_ALU.vhd
+++ b/t80/T80_ALU.vhd
@@ -216,35 +216,64 @@ begin
 			end if;
 		when "1100" =>
 			-- DAA
-			F_Out(Flag_H) <= F_In(Flag_H);
-			F_Out(Flag_C) <= F_In(Flag_C);
-			DAA_Q(7 downto 0) := unsigned(BusA);
-			DAA_Q(8) := '0';
-			if F_In(Flag_N) = '0' then
-				-- After addition
-				-- Alow > 9 or H = 1
-				if DAA_Q(3 downto 0) > 9 or F_In(Flag_H) = '1' then
-					if (DAA_Q(3 downto 0) > 9) then
-						F_Out(Flag_H) <= '1';
-					else
-						F_Out(Flag_H) <= '0';
+			if Mode = 3 then
+				F_Out(Flag_H) <= '0';
+				F_Out(Flag_C) <= F_In(Flag_C);
+				DAA_Q(7 downto 0) := unsigned(BusA);
+				DAA_Q(8) := '0';
+				if F_In(Flag_N) = '0' then
+					-- After addition
+					-- Alow > 9 or H = 1
+					if DAA_Q(3 downto 0) > 9 or F_In(Flag_H) = '1' then
+							DAA_Q := DAA_Q + 6;
 					end if;
-					DAA_Q := DAA_Q + 6;
-				end if;
-				-- new Ahigh > 9 or C = 1
-				if DAA_Q(8 downto 4) > 9 or F_In(Flag_C) = '1' then
-					DAA_Q := DAA_Q + 96; -- 0x60
+					-- new Ahigh > 9 or C = 1
+					if DAA_Q(8 downto 4) > 9 or F_In(Flag_C) = '1' then
+						DAA_Q := DAA_Q + 96; -- 0x60
+					end if;
+				else
+					-- After subtraction
+					if F_In(Flag_H) = '1' then
+						DAA_Q := DAA_Q - 6;
+						if F_In(Flag_C) = '0' then
+							DAA_Q(8) := '0';
+						end if;
+					end if;
+					if F_In(Flag_C) = '1' then
+						DAA_Q := DAA_Q - 96; -- 0x60
+					end if;
 				end if;
 			else
-				-- After subtraction
-				if DAA_Q(3 downto 0) > 9 or F_In(Flag_H) = '1' then
-					if DAA_Q(3 downto 0) > 5 then
-						F_Out(Flag_H) <= '0';
+				F_Out(Flag_H) <= F_In(Flag_H);
+				F_Out(Flag_C) <= F_In(Flag_C);
+				DAA_Q(7 downto 0) := unsigned(BusA);
+				DAA_Q(8) := '0';
+				if F_In(Flag_N) = '0' then
+					-- After addition
+					-- Alow > 9 or H = 1
+					if DAA_Q(3 downto 0) > 9 or F_In(Flag_H) = '1' then
+						if (DAA_Q(3 downto 0) > 9) then
+							F_Out(Flag_H) <= '1';
+						else
+							F_Out(Flag_H) <= '0';
+						end if;
+						DAA_Q := DAA_Q + 6;
 					end if;
-					DAA_Q(7 downto 0) := DAA_Q(7 downto 0) - 6;
-				end if;
-				if unsigned(BusA) > 153 or F_In(Flag_C) = '1' then
-					DAA_Q := DAA_Q - 352; -- 0x160
+					-- new Ahigh > 9 or C = 1
+					if DAA_Q(8 downto 4) > 9 or F_In(Flag_C) = '1' then
+						DAA_Q := DAA_Q + 96; -- 0x60
+					end if;
+				else
+					-- After subtraction
+					if DAA_Q(3 downto 0) > 9 or F_In(Flag_H) = '1' then
+						if DAA_Q(3 downto 0) > 5 then
+							F_Out(Flag_H) <= '0';
+						end if;
+						DAA_Q(7 downto 0) := DAA_Q(7 downto 0) - 6;
+					end if;
+					if unsigned(BusA) > 153 or F_In(Flag_C) = '1' then
+						DAA_Q := DAA_Q - 352; -- 0x160
+					end if;
 				end if;
 			end if;
 			F_Out(Flag_X) <= DAA_Q(3);


### PR DESCRIPTION
Fixed the T80 core to resume after an IRQ even if IME is not set, the IRQ is not services and resumes executing from PC.

DAA is slightly different from a Z80

Fixes LD HL,SP+dd and ADD SP,dd flags

This core now passes most of the Blargg's CPU Instruction Tests only 09 remaining. 
Compared to a emulator trace the supposedly faulty instructions execute correctly but something wrong happens when it compares checksums, but I couldn't find out what yet ...

http://gbdev.gg8.se/wiki/articles/Test_ROMs