### PR TITLE
Sound Fixes , Dummy Serial Port and Video Fix

### DIFF
--- a/gb.v
+++ b/gb.v
@@ -55,8 +55,6 @@ wire sel_video_oam = cpu_addr[15:8] == 8'hfe;
 wire sel_joy  = cpu_addr == 16'hff00;                // joystick controller
 wire sel_sb  = cpu_addr == 16'hff01;  			        // serial SB - Serial transfer data
 wire sel_sc  = cpu_addr == 16'hff02;  			        // SC - Serial Transfer Control (R/W)
-wire sel_nr50 = cpu_addr == 16'hff24;					  // Channel control / ON-OFF / Volume (R/W) //readonly no games use it
-wire sel_nr51 = cpu_addr == 16'hff25;					  // Selection of Sound output terminal (R/W) //readonly no games use it
 wire sel_rom  = !cpu_addr[15];                       // lower 32k are rom
 wire sel_cram = cpu_addr[15:13] == 3'b101;           // 8k cart ram at $a000
 wire sel_vram = cpu_addr[15:13] == 3'b100;           // 8k video ram at $8000
@@ -88,8 +86,6 @@ wire [7:0] cpu_di =
 		sel_timer?timer_do:     // timer registers
 		sel_video_reg?video_do: // video registers
 		sel_video_oam?video_do: // video object attribute memory
-		sel_nr50?8'h77:
-		sel_nr51?8'hF3:
 		sel_audio?audio_do:     // audio registers
 		sel_rom?rom_do:         // boot rom + cartridge rom
 		sel_cram?rom_do:        // cartridge ram

--- a/gbc_snd.vhd
+++ b/gbc_snd.vhd
@@ -646,15 +646,16 @@ begin
 				end if;
 
 			end if;
+			
+			-- Length counter
+			if en_len then
+				if sq1_len > 0 and sq1_lenchk = '1' then
+					sq1_len := std_logic_vector(unsigned(sq1_len) - 1);
+				end if;
+			end if;
 
 			-- Square channel 1
 			if sq1_playing = '1' then
-				-- Length counter
-				if en_len then
-					if sq1_len > 0 then
-						sq1_len := std_logic_vector(unsigned(sq1_len) - 1);
-					end if;
-				end if;
 
 				-- Envelope counter
 				if en_env then
@@ -724,6 +725,9 @@ begin
 			
 			if sq1_trigger = '1' or sq1_volchange = '1' then
 				sq1_vol <= sq1_svol;
+				if sq1_svol = "00000" and sq1_envsgn = '0' then -- dac disabled
+					sq1_playing <= '0';
+				end if;
 			end if;
 			
 			if sq1_lenchange = '1' then
@@ -736,7 +740,9 @@ begin
 				sq1_fr2 <= sq1_freq;
 				sq1_fcnt := unsigned(sq1_freq);
 				noi_lfsr := (others => '1');
-				sq1_playing <= '1';
+				if not (sq1_svol = "00000" and sq1_envsgn = '0') then -- dac enabled
+					sq1_playing <= '1';
+				end if;
 				sq1_envcnt := "000";
 				sq1_swcnt := "000";	
 				sq1_phase := 0;
@@ -744,16 +750,17 @@ begin
 					sq1_len := "1000000";
 				end if;
 			end if;
+			
+			-- Length counter
+			if en_len then
+				if sq2_len > 0 and sq2_lenchk = '1' then
+					-- sq2_len := std_logic_vector(unsigned(sq2_len) + to_unsigned(1, sq2_len'length));
+					sq2_len := std_logic_vector(unsigned(sq2_len) - 1);
+				end if;
+			end if;
 
 			-- Square channel 2
 			if sq2_playing = '1' then
-				-- Length counter
-				if en_len then
-					if sq2_len > 0 then
-						-- sq2_len := std_logic_vector(unsigned(sq2_len) + to_unsigned(1, sq2_len'length));
-						sq2_len := std_logic_vector(unsigned(sq2_len) - 1);
-					end if;
-				end if;
 
 				-- Envelope counter
 				if en_env then
@@ -786,6 +793,9 @@ begin
 			
 			if sq2_volchange ='1' or sq2_trigger= '1' then
 				sq2_vol <= sq2_svol;
+				if sq2_svol = "00000" and sq2_envsgn = '0' then -- dac disabled
+					sq2_playing <= '0';
+				end if;
 			end if;
 			
 			if sq2_lenchange = '1' then
@@ -796,7 +806,9 @@ begin
 			if sq2_trigger = '1' then
 				sq2_fr2 <= sq2_freq;
 				sq2_fcnt := unsigned(sq2_freq);
-				sq2_playing <= '1';
+				if not (sq2_svol = "00000" and sq2_envsgn = '0') then -- dac enabled
+					sq2_playing <= '1';
+				end if;
 				sq2_envcnt := "000";
 				sq2_phase := 0;
 				if sq2_len = 0 then

--- a/gbc_snd.vhd
+++ b/gbc_snd.vhd
@@ -90,6 +90,7 @@ architecture SYN of gbc_snd is
 	signal wav_wav			: std_logic_vector(5 downto 0);		-- Wave output waveform
 	signal wav_ram			: wav_arr_t;											-- Wave table
 	signal wav_shift		: boolean;
+	signal wav_index		: unsigned(4 downto 0);
 
 	signal noi_slen		: std_logic_vector(5 downto 0);
 	signal noi_svol		: std_logic_vector(3 downto 0);
@@ -225,6 +226,7 @@ begin
 			
 			ch_map 		<= (others => '0');
 	      ch_vol		<= (others => '0');
+			wav_index	<= (others => '0');
 
 		elsif rising_edge(clk) then
 			if en_snd then
@@ -236,11 +238,12 @@ begin
 
 			-- Rotate wave table on rising edge of wav_shift
 			if wav_shift and not wav_shift_r then
-				wav_temp := wav_ram(0);
-				for I in 0 to 30 loop
-					wav_ram(I) <= wav_ram(I+1);
-				end loop;
-				wav_ram(31) <= wav_temp;
+--				wav_temp := wav_ram(0);
+--				for I in 0 to 30 loop
+--					wav_ram(I) <= wav_ram(I+1);
+--				end loop;
+--				wav_ram(31) <= wav_temp;
+				wav_index <= wav_index + 1;
 			end if;
 			
 			sq2_volchange <= '0';
@@ -892,9 +895,12 @@ begin
 
 			if wav_enable = '1' and wav_volsh /= "00" then
 				case wav_volsh is
-				when "01" => wav_wav <= wav_ram(0) & "00";
-				when "10" => wav_wav <= '0' & wav_ram(0) & '0';
-				when "11" => wav_wav <= "00" & wav_ram(0);
+--				when "01" => wav_wav <= wav_ram(0) & "00";
+--				when "10" => wav_wav <= '0' & wav_ram(0) & '0';
+--				when "11" => wav_wav <= "00" & wav_ram(0);
+				when "01" => wav_wav <= wav_ram(to_integer(wav_index)) & "00";
+				when "10" => wav_wav <= '0' & wav_ram(to_integer(wav_index)) & '0';
+				when "11" => wav_wav <= "00" & wav_ram(to_integer(wav_index));
 				when others => wav_wav <= (others => 'X');
 				end case;
 			else

--- a/gbc_snd.vhd
+++ b/gbc_snd.vhd
@@ -750,7 +750,6 @@ begin
 			if sq1_trigger = '1' then
 				sq1_fr2 <= sq1_freq;
 				sq1_fcnt := unsigned(sq1_freq);
-				noi_lfsr := (others => '1');
 				if not (sq1_svol = "00000" and sq1_envsgn = '0') then -- dac enabled
 					sq1_playing <= '1';
 				end if;
@@ -890,7 +889,7 @@ begin
 				when "110" => noi_divisor := to_unsigned(2048 - 96, noi_divisor'length);
 				when others => noi_divisor := to_unsigned(2048 - 112, noi_divisor'length);
 				end case;
-
+				noi_lfsr := (others => '1');
 --				case noi_freqsh is
 --				when "000" => noi_freq := unsigned(noi_divisor);
 --				when "001" => noi_freq := '0' & unsigned(noi_divisor(10 downto 1));

--- a/video.v
+++ b/video.v
@@ -168,7 +168,7 @@ always @(posedge clk) begin
 	
 	//TODO: investigate and fix timing of lyc=ly
 	// lyc=ly coincidence
-	if(stat[6] && (h_cnt == 250) && lyc_match) //h_cnt==0 too late, when early(say h_count=1 messes up radarmission)
+	if(stat[6] && (h_cnt == 1) && lyc_match) //h_cnt==0 too late, when early(say h_count=1 messes up radarmission)
 		irq <= 1'b1;
 		
 	// begin of oam phase


### PR DESCRIPTION
This PR fixes the Sound Length counter issues (mainly looping sounds), the APU still needs work (the noise generator is often "wrong" among other issues) , now passes the first 2 Blargg's DMG sound tests

Implements a Dummy Serial Port (returns 0xFF a.k.a. "not connected" and triggers interrupt) , Alleyway is now playable

Triggers LY==LYC interrupt earlier, this fixes  Final Fantasy Legend 1+2 and improves Mario Picross