### PR TITLE
Fixed LY register

### DIFF
--- a/gb.v
+++ b/gb.v
@@ -76,7 +76,7 @@ wire dma_sel_iram = (dma_addr[15:14] == 2'b11) && (dma_addr[15:8] != 8'hff); // 
 // the boot roms sees a special $42 flag in $ff50 if it's supposed to to a fast boot
 wire sel_fast = fast_boot && cpu_addr == 16'hff50 && boot_rom_enabled;
 
-wire sc_r = {sc_start,6'h3F,sc_shiftclock};
+wire [7:0] sc_r = {sc_start,6'h3F,sc_shiftclock};
 				
 // http://gameboy.mongenel.com/dmg/asmmemmap.html
 wire [7:0] cpu_di = 

--- a/gbc_snd.vhd
+++ b/gbc_snd.vhd
@@ -1141,23 +1141,23 @@ begin
 	-- Mixer
 	mixer : process(sq1_wav, sq2_wav, noi_wav, wav_wav, ch_map, ch_vol)
 		variable snd_left_in		: unsigned(7 downto 0);
-		variable snd_right_in		: unsigned(7 downto 0);
+		variable snd_right_in	: unsigned(7 downto 0);
 	begin
 		snd_left_in := (others => '0');
 		snd_right_in := (others => '0');
 
-		if ch_map(0) = '1' then snd_left_in  := snd_left_in  + ("00"&unsigned(sq1_wav)); end if;
-		if ch_map(1) = '1' then snd_left_in  := snd_left_in  + ("00"&unsigned(sq2_wav)); end if;
-		if ch_map(2) = '1' then snd_left_in  := snd_left_in  + ("00"&unsigned(wav_wav)); end if;
-		if ch_map(3) = '1' then snd_left_in  := snd_left_in  + ("00"&unsigned(noi_wav)); end if;
+		if ch_map(0) = '1' then snd_right_in  := snd_right_in  + ("00"&unsigned(sq1_wav)); end if;
+		if ch_map(1) = '1' then snd_right_in  := snd_right_in  + ("00"&unsigned(sq2_wav)); end if;
+		if ch_map(2) = '1' then snd_right_in  := snd_right_in  + ("00"&unsigned(wav_wav)); end if;
+		if ch_map(3) = '1' then snd_right_in  := snd_right_in  + ("00"&unsigned(noi_wav)); end if;
 
-		if ch_map(4) = '1' then snd_right_in := snd_right_in + ("00"&unsigned(sq1_wav)); end if;
-		if ch_map(5) = '1' then snd_right_in := snd_right_in + ("00"&unsigned(sq2_wav)); end if;
-		if ch_map(6) = '1' then snd_right_in := snd_right_in + ("00"&unsigned(wav_wav)); end if;
-		if ch_map(7) = '1' then snd_right_in := snd_right_in + ("00"&unsigned(noi_wav)); end if;
+		if ch_map(4) = '1' then snd_left_in := snd_left_in + ("00"&unsigned(sq1_wav)); end if;
+		if ch_map(5) = '1' then snd_left_in := snd_left_in + ("00"&unsigned(sq2_wav)); end if;
+		if ch_map(6) = '1' then snd_left_in := snd_left_in + ("00"&unsigned(wav_wav)); end if;
+		if ch_map(7) = '1' then snd_left_in := snd_left_in + ("00"&unsigned(noi_wav)); end if;
 
-		snd_left  <= (std_logic_vector(snd_left_in)  & "00000") * ch_vol(2 downto 0);
-		snd_right <= (std_logic_vector(snd_right_in) & "00000") * ch_vol(6 downto 4);
+		snd_right  <= (std_logic_vector(snd_right_in)  & "00000") * ch_vol(2 downto 0);
+		snd_left <= (std_logic_vector(snd_left_in) & "00000") * ch_vol(6 downto 4);
 	end process;
 
 end SYN;

--- a/video.v
+++ b/video.v
@@ -120,7 +120,7 @@ reg [7:0] scx;
 reg [7:0] scx_r;   // stable over line
 
 // ff44 line counter
-reg [7:0] ly;
+wire [7:0] ly = v_cnt;
 
 // ff45 line counter compare
 wire lyc_match = (ly == lyc);
@@ -463,12 +463,8 @@ always @(negedge clk or negedge lcdc_on) begin
 		//reset counters
 		h_cnt <= 9'd0;  
 		v_cnt <= 8'd0;
-		ly <= 8'd0;
 		
 	end else begin
-		// this ly change h_cnt is wrong!!!
-		if(h_cnt == 0)
-			ly <= (v_cnt >= 153)?(v_cnt-8'd153):(v_cnt+8'd1);
 	
 		if(h_cnt != 455) begin
 			h_cnt <= h_cnt + 9'd1;


### PR DESCRIPTION
Small (in code) but huge (in compatibility) change.

LY registers simply needs do follow v_cnt, fixes a LOT of games, some that I've checked:

Screen alignement issues :
Mario land, Mario's Picross, Pinball, Alleyway among many others

Screen corruption:
Micro Machines, Donkey Kong Land

Infinite loops(games that use LY to check if in V-sync):
Worms, Uno 1+2, A boy and his blob, Super R.C. Pro-Am, Wario Land II

