### PR TITLE
Auto save loading and optional writing on OSD

### DIFF
--- a/Gameboy.sv
+++ b/Gameboy.sv
@@ -116,8 +116,8 @@ assign {UART_RTS, UART_TXD, UART_DTR} = 0;
 
 assign {SD_SCK, SD_MOSI, SD_CS} = 'Z;
 
-assign LED_USER  = ioctl_download;
-assign LED_DISK  = sav_pending;
+assign LED_USER  = ioctl_download | sav_pending;
+assign LED_DISK  = 0;
 assign LED_POWER = 0;
 
 assign VIDEO_ARX = status[4:3] == 2'b10 ? 8'd16:
@@ -144,7 +144,7 @@ localparam CONF_STR1 = {
 localparam CONF_STR2 = {
 	",GBP,Load Palette;",
 	"-;",
-	"OD,Opening OSD saves,Yes,No;",
+	"OD,OSD triggered autosaves,No,Yes;",
 };
 
 localparam CONF_STR3 = {
@@ -711,7 +711,7 @@ always @(posedge clk_sys) begin
 end
 
 wire bk_load    = status[9] | new_load;
-wire bk_save    = status[10] | (sav_pending & OSD_STATUS & ~status[13]);
+wire bk_save    = status[10] | (sav_pending & OSD_STATUS & status[13]);
 reg  bk_loading = 0;
 reg  bk_state   = 0;
 

--- a/sys/osd.v
+++ b/sys/osd.v
@@ -13,7 +13,8 @@ module osd
 	input  [23:0] din,
 	output [23:0] dout,
 	input         de_in,
-	output reg    de_out
+	output reg    de_out,
+	output        osd_status
 );
 
 parameter  OSD_COLOR    =  3'd4;
@@ -32,6 +33,8 @@ reg  [8:0] infow;
 reg [11:0] infox;
 reg [21:0] infoy;
 reg [21:0] hrheight;
+
+assign osd_status = osd_enable;
 
 always@(posedge clk_sys) begin
 	reg [11:0] bcnt;

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -749,7 +749,9 @@ osd hdmi_osd
 	.din(hdmi_data_sl),
 	.dout(HDMI_TX_D),
 	.de_in(hdmi_de),
-	.de_out(HDMI_TX_DE)
+	.de_out(HDMI_TX_DE),
+
+	.osd_status(osd_status)
 );
 
 assign HDMI_MCLK = 0;
@@ -937,6 +939,7 @@ wire        uart_cts;
 wire        uart_rts;
 wire        uart_rxd;
 wire        uart_txd;
+wire        osd_status;
 
 emu emu
 (
@@ -1009,7 +1012,9 @@ emu emu
 	.UART_RXD(uart_txd),
 	.UART_TXD(uart_rxd),
 	.UART_DTR(uart_dsr),
-	.UART_DSR(uart_dtr)
+	.UART_DSR(uart_dtr),
+
+	.OSD_STATUS(osd_status)
 );
 
 endmodule


### PR DESCRIPTION
Save will load automatically if the ROM type indicates it has RAM and a battery.

If menu option is enabled, the save ram will be recorded to disk when the OSD opens only if the following is true:
-the game has backup ram
-the game has a battery
-the save ram has been written at least once since the last save operation

The disk write LED is used to indicate a save is pending and needs to be written.

In practice this makes saves work more transparently with minimal risk of data corruption and without excessive SD card wear.

