### PR TITLE
Video Fixes

### DIFF
--- a/gb.v
+++ b/gb.v
@@ -511,7 +511,7 @@ wire cpu_wr_iram = sel_iram && !cpu_wr_n;
 wire [7:0] iram_do;
 spram #(15) iram (
 	.clock      ( clk_cpu        ),
-	.address    ( {iram_bank,iram_addr[14:0]} ),
+	.address    ( iram_addr      ),
 	.wren       ( iram_wren      ),
 	.data       ( cpu_do         ),
 	.q          ( iram_do        )

--- a/hdma.v
+++ b/hdma.v
@@ -85,12 +85,14 @@ always @(posedge clk) begin
 					hdma_16byte_cnt <= hdma_16byte_cnt - 1'd1;
 					if (!hdma_16byte_cnt) begin
 							hdma_length <= hdma_length - 1'd1;
+							if (hdma_length == 1) begin
+								hdma_active <= 1'b0;
+								hdma_enabled <= 1'b0;
+								hdma_length <= 8'h80; //7f+1
+							end
 				   end	
-				end else begin
-					hdma_active <= 1'b0;
-					hdma_enabled <= 1'b0;
-					hdma_length <= 8'h80; //7f+1
-				end
+				end 
+
 			end else begin        			                       //mode 1 HDMA transfer 1 block (16bytes) in each H-Blank only
 				case (hdma_state)
 					


### PR DESCRIPTION
HDMA in GDMA mode fixed, was overflowing in the last chunk. This should fix graphical glitches in a lot of games.

GBC BG priority bit implemented, fixes "Zelda Oracle of" games text boxes among other things.