### PR TITLE
GB Mode sprite regression Fix

### DIFF
--- a/t80/T80_MCode.vhd
+++ b/t80/T80_MCode.vhd
@@ -942,9 +942,19 @@ begin
 			end if;
 		when "00001011"|"00011011"|"00101011"|"00111011" =>
 			-- DEC ss
-			TStates <= "110";
-			IncDec_16(3 downto 2) <= "11";
-			IncDec_16(1 downto 0) <= DPair;
+			if Mode = 3 then
+				MCycles <= "010";
+				case to_integer(unsigned(MCycle)) is
+				when 2 =>
+					IncDec_16(3 downto 2) <= "11";
+					IncDec_16(1 downto 0) <= DPair;
+				when others =>
+				end case;
+			else
+				TStates <= "110";
+				IncDec_16(3 downto 2) <= "11";
+				IncDec_16(1 downto 0) <= DPair;
+			end if;
 
 -- ROTATE AND SHIFT GROUP
 		when "00000111"

--- a/video.v
+++ b/video.v
@@ -90,11 +90,11 @@ sprites sprites (
 	.pixel_cmap   ( sprite_pixel_cmap   ),
 	.pixel_prio   ( sprite_pixel_prio   ),
 
-	.index    ( sprite_index ),
-	.addr     ( sprite_addr  ),
-	.dvalid   ( sprite_dvalid),
-	.data     ( vram_data    ),
-	.data1    ( vram1_data   ),
+	.index    ( sprite_index                ),
+	.addr     ( sprite_addr                 ),
+	.dvalid   ( sprite_dvalid               ),
+	.data     ( vram_data                   ),
+	.data1    ( isGBC?vram1_data:vram_data  ),
 	
 	//gbc
 	.pixel_cmap_gbc ( sprite_pixel_cmap_gbc ),


### PR DESCRIPTION
Fixes the sprite regression in gameboy games (e.g.: xenon 2 and prehistorik man)
Fixes the 16 bit DEC rr Opcode timing (longer on GB than Z80)

As the fast boot feature breaks lots of games and a lot of bug reports are related to it , it should be probably be disabled while a better solution isn't implemented yet (set the t80 and peripherals to the state after the bootrom), what do you think ? 