### PR TITLE
Timing Fixes (Mostly)

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,8 +5,8 @@ This is port of [Gameboy for MiST](https://github.com/mist-devel/mist-board/tree
 * Place RBF file into root of SD card.
 * Place *.gb files into Gameboy folder.
 
-## **Early** Gameboy Color Support
-Place the Gameboy color bootrom into the Gameboy folder and rename it to boot1.rom
+## Gameboy Color Support
+Place the Gameboy color bios/bootrom into the Gameboy folder and rename it to boot1.rom
 
 ## Palettes
 Core supports custom palettes (*.gbp) which should be places into Gameboy folder. Some examples are available in palettes folder.

--- a/gb.v
+++ b/gb.v
@@ -278,8 +278,8 @@ wire [7:0] irq_vec =
 			if_r[4]&&ie_r[4]?8'h60:   // input
 			8'h55;
 
-wire vs = (lcd_mode == 2'b01);
-reg vsD, vsD2;
+//wire vs = (lcd_mode == 2'b01);
+//reg vsD, vsD2;
 reg [7:0] inputD, inputD2;
 
 // irq is low when an enable irq is active
@@ -296,9 +296,9 @@ always @(negedge clk_cpu) begin //negedge to trigger interrupt earlier
 	end
 
 	// rising edge on vs
-	vsD <= vs;
-	vsD2 <= vsD;
-	if(vsD && !vsD2) if_r[0] <= 1'b1;
+//	vsD <= vs;
+//	vsD2 <= vsD;
+	if(vblank_irq) if_r[0] <= 1'b1;
 
 	// video irq already is a 1 clock event
 	if(video_irq) if_r[1] <= 1'b1;
@@ -359,7 +359,7 @@ timer timer (
 // --------------------------------------------------------------------
 
 // cpu tries to read or write the lcd controller registers
-wire video_irq;
+wire video_irq,vblank_irq;
 wire [7:0] video_do;
 wire [12:0] video_addr;
 wire [15:0] dma_addr;
@@ -375,6 +375,8 @@ video video (
 	
 
 	.irq         ( video_irq     ),
+	.vblank_irq  ( vblank_irq    ),
+
 
 	.cpu_sel_reg ( sel_video_reg ),
 	.cpu_sel_oam ( sel_video_oam ),

--- a/gb.v
+++ b/gb.v
@@ -115,11 +115,11 @@ wire [7:0] cpu_di =
 		sel_sc?sc_r:				// serial transfer control register
 		sel_timer?timer_do:     // timer registers
 		sel_video_reg?video_do: // video registers
-		sel_video_oam?video_do: // video object attribute memory
+		(sel_video_oam&&!(lcd_mode==3 || lcd_mode==2))?video_do: // video object attribute memory
 		sel_audio?audio_do:                                // audio registers
 		sel_rom?rom_do:                                    // boot rom + cartridge rom
 		sel_cram?rom_do:                                   // cartridge ram
-		sel_vram?(isGBC&&vram_bank)?vram1_do:vram_do:       // vram (GBC bank 0+1)
+		(sel_vram&&lcd_mode!=3)?(isGBC&&vram_bank)?vram1_do:vram_do:       // vram (GBC bank 0+1)
 		sel_zpram?zpram_do:     // zero page ram
 		sel_iram?iram_do:       // internal ram
 		sel_ie?{3'b000, ie_r}:  // interrupt enable register
@@ -404,7 +404,7 @@ video video (
 );
 
 // total 8k/16k (CGB) vram from $8000 to $9fff
-wire cpu_wr_vram = sel_vram && !cpu_wr_n;
+wire cpu_wr_vram = sel_vram && !cpu_wr_n && lcd_mode!=3;
 
 reg vram_bank; //0-1 FF4F - VBK
 

--- a/t80/GBse.vhd
+++ b/t80/GBse.vhd
@@ -74,7 +74,7 @@ use work.T80_Pack.all;
 
 entity GBse is
 	generic(
-		T2Write : integer := 0;  -- 0 => WR_n active in T3, /=0 => WR_n active in T2
+		T2Write : integer := 1;  -- 0 => WR_n active in T3, /=0 => WR_n active in T2
 		IOWait : integer := 1   -- 0 => Single cycle I/O, 1 => Std I/O cycle
 	);
 	port(

--- a/t80/T80_ALU.vhd
+++ b/t80/T80_ALU.vhd
@@ -155,7 +155,7 @@ begin
 		end if;
 	end process;
 
-	process (Arith16, ALU_OP, F_In, BusA, BusB, IR, Q_v, Carry_v, HalfCarry_v, OverFlow_v, BitMask, ISet, Z16)
+	process (Arith16, ALU_OP, F_In, BusA, BusB, IR, Q_v, Carry_v, HalfCarry_v, OverFlow_v, BitMask, ISet, Z16, Rot_Akku)
 		variable Q_t : std_logic_vector(7 downto 0);
 		variable DAA_Q : unsigned(8 downto 0);
 	begin

--- a/t80/T80_MCode.vhd
+++ b/t80/T80_MCode.vhd
@@ -517,8 +517,10 @@ begin
 			end if;
 		when "11111001" =>
 			-- LD SP,HL
-			TStates <= "110";
-			LDSPHL <= '1';
+			MCycles <= "010";
+			if MCycle = "010" then
+				LDSPHL <= '1';
+			end if;
 		when "11000101"|"11010101"|"11100101"|"11110101" =>
 			-- PUSH qq
 			if Mode = 3 then
@@ -845,34 +847,50 @@ begin
 				end case;
 			elsif IntCycle = '1' then
 				-- INT (IM 2)
-        if mode = 3 then
-          MCycles <= "011";
-        else
-          MCycles <= "101";
-        end if;
-				case to_integer(unsigned(MCycle)) is
-				when 1 =>
-					LDZ <= '1';
-					TStates <= "101";
-					IncDec_16 <= "1111";
-					Set_Addr_To <= aSP;
-					Set_BusB_To <= "1101";
-				when 2 =>
-					TStates <= "100";
-					Write <= '1';
-					IncDec_16 <= "1111";
-					Set_Addr_To <= aSP;
-					Set_BusB_To <= "1100";
-				when 3 =>
-					TStates <= "100";
-					Write <= '1';
-				when 4 =>
-					Inc_PC <= '1';
-					LDZ <= '1';
-				when 5 =>
-					Jump <= '1';
-				when others => null;
-				end case;
+				if mode = 3 then
+				 MCycles <= "100";
+				 case to_integer(unsigned(MCycle)) is
+					when 1 =>
+						LDZ <= '1';
+						TStates <= "110";
+						IncDec_16 <= "1111";
+						Set_Addr_To <= aSP;
+						Set_BusB_To <= "1101";
+					when 2 =>
+						Write <= '1';
+						IncDec_16 <= "1111";
+						Set_Addr_To <= aSP;
+						Set_BusB_To <= "1100";
+					when 3 =>
+						Write <= '1';
+					when others => null;
+					end case;
+				else
+				 MCycles <= "101";
+				 case to_integer(unsigned(MCycle)) is
+					when 1 =>
+						LDZ <= '1';
+						TStates <= "101";
+						IncDec_16 <= "1111";
+						Set_Addr_To <= aSP;
+						Set_BusB_To <= "1101";
+					when 2 =>
+						TStates <= "100";
+						Write <= '1';
+						IncDec_16 <= "1111";
+						Set_Addr_To <= aSP;
+						Set_BusB_To <= "1100";
+					when 3 =>
+						TStates <= "100";
+						Write <= '1';
+					when 4 =>
+						Inc_PC <= '1';
+						LDZ <= '1';
+					when 5 =>
+						Jump <= '1';
+					when others => null;
+					end case;
+				end if;
 			else
 				-- NOP
 			end if;
@@ -1048,7 +1066,11 @@ begin
 				end case;
 			else
 				-- JP cc,nn
-				MCycles <= "011";
+				if Mode = 3 then
+					MCycles <= "100";
+				else
+					MCycles <= "011";
+				end if;
 				case to_integer(unsigned(MCycle)) is
 				when 2 =>
 					Inc_PC <= '1';
@@ -1057,6 +1079,8 @@ begin
 					Inc_PC <= '1';
 					if is_cc_true(F, to_bitvector(IR(5 downto 3))) then
 						Jump <= '1';
+					else
+						MCycles <= "011";
 					end if;
 				when others => null;
 				end case;

--- a/t80/T80_MCode.vhd
+++ b/t80/T80_MCode.vhd
@@ -1364,25 +1364,41 @@ begin
 			-- RST p
 			if Mode = 3 then
 				MCycles <= "100";
+				case to_integer(unsigned(MCycle)) is
+				when 2 =>
+					TStates <= "101";
+					IncDec_16 <= "1111";
+					Set_Addr_To <= aSP;
+					Set_BusB_To <= "1101";
+				when 3 =>
+					Write <= '1';
+					IncDec_16 <= "1111";
+					Set_Addr_To <= aSP;
+					Set_BusB_To <= "1100";
+				when 4 =>
+					Write <= '1';
+					RstP <= '1';
+				when others => null;
+				end case;
 			else
 				MCycles <= "011";
-			end if;
-			case to_integer(unsigned(MCycle)) is
-			when 1 =>
-				TStates <= "101";
-				IncDec_16 <= "1111";
-				Set_Addr_To <= aSP;
-				Set_BusB_To <= "1101";
-			when 2 =>
-				Write <= '1';
-				IncDec_16 <= "1111";
-				Set_Addr_To <= aSP;
-				Set_BusB_To <= "1100";
-			when 3 =>
-				Write <= '1';
-				RstP <= '1';
-			when others => null;
-			end case;
+				case to_integer(unsigned(MCycle)) is
+				when 1 =>
+					TStates <= "101";
+					IncDec_16 <= "1111";
+					Set_Addr_To <= aSP;
+					Set_BusB_To <= "1101";
+				when 2 =>
+					Write <= '1';
+					IncDec_16 <= "1111";
+					Set_Addr_To <= aSP;
+					Set_BusB_To <= "1100";
+				when 3 =>
+					Write <= '1';
+					RstP <= '1';
+				when others => null;
+				end case;
+		   end if;
 
 -- INPUT AND OUTPUT GROUP
 		when "11011011" =>

--- a/timer.v
+++ b/timer.v
@@ -49,10 +49,10 @@ wire resetdiv = cpu_sel && cpu_wr && (cpu_addr == 2'b00); //resetdiv also resets
 reg [9:0] clk_div;
 always @(posedge clk or posedge resetdiv)
 	if(resetdiv)
-	  clk_div <= 10'd6;
+	  clk_div <= 10'd2;
 	else
 		if (reset)
-		     clk_div <= 10'd6;
+		     clk_div <= 10'd8;
 		  else
 	        clk_div <= clk_div + 10'd1;
 

--- a/video.v
+++ b/video.v
@@ -585,7 +585,7 @@ always @(negedge clk) begin
 
 	if (!lcdc_on) begin // don't increase counters if lcdoff 
 		//reset counters
-		h_cnt <= 9'd4;  
+		h_cnt <= 9'd6;  
 		v_cnt <= 8'd0;
 		
 	end else begin

--- a/video.v
+++ b/video.v
@@ -57,6 +57,7 @@ module video (
 localparam STAGE2  = 9'd250;   // oam + disp + pause
 localparam OAM_LEN = 80;
 localparam OAM_LEN16 = OAM_LEN/16;
+localparam MODE3_OFFSET = 8'd16;
 
 wire sprite_pixel_active;
 wire [1:0] sprite_pixel_data;
@@ -462,7 +463,7 @@ wire vblank  = (v_cnt >= 144);
 
 // x scroll & 7 needs one more memory read per line
 reg [1:0] hextra_tiles;
-wire [7:0] hextra = { 3'b000, hextra_tiles, 3'b000 };
+wire [7:0] hextra = { 3'b000, hextra_tiles, 3'b000 }+MODE3_OFFSET;
 wire hblank  = ((h_cnt < OAM_LEN) || (h_cnt >= 160+OAM_LEN+hextra));
 wire oam     = (h_cnt < OAM_LEN);                            // 80 clocks oam
 wire stage2  = ((h_cnt >= STAGE2) && (h_cnt < STAGE2+160));  // output out of stage2
@@ -546,6 +547,7 @@ wire bg_tile_obj_rd = (!vblank) && (!hblank) && (h_cnt[2:1] == 2'b11);
 // Mode 10:  oam
 // Mode 11:  oam and vram
 assign mode = 
+	(ly <= 144 && h_cnt<4)?2'b00:  //AntonioND https://github.com/AntonioND/giibiiadvance/blob/master/docs/TCAGBD.pdf
    !lcdc_on?2'b00:
 	vblank?2'b01:
 	oam?2'b10:

--- a/video.v
+++ b/video.v
@@ -581,11 +581,11 @@ wire win_start = lcdc_win_ena && (v_cnt >= wy_r) && de && (wx_r >= 7) && (pcnt =
 
 
 // each memory access takes two cycles
-always @(negedge clk or negedge lcdc_on) begin
+always @(negedge clk) begin
 
 	if (!lcdc_on) begin // don't increase counters if lcdoff 
 		//reset counters
-		h_cnt <= 9'd0;  
+		h_cnt <= 9'd4;  
 		v_cnt <= 8'd0;
 		
 	end else begin

--- a/video.v
+++ b/video.v
@@ -38,6 +38,7 @@ module video (
 	output lcd_clkena,
 	output [14:0] lcd_data,
 	output reg irq,
+	output reg vblank_irq,
 	
 	// vram connection
 	output [1:0] mode,
@@ -198,6 +199,7 @@ end
 
 always @(posedge clk_reg) begin  //TODO: have to check if this is correct
 	irq <= 1'b0;
+	vblank_irq <= 1'b0;
 	
 	//TODO: investigate and fix timing of lyc=ly
 	// lyc=ly coincidence
@@ -209,8 +211,11 @@ always @(posedge clk_reg) begin  //TODO: have to check if this is correct
 		irq <= 1'b1;
 
 	// begin of vblank
-	if(stat[4] && (h_cnt == 455) && (v_cnt == 143))
-		irq <= 1'b1;
+	if((h_cnt == 455) && (v_cnt == 143)) begin
+		if (stat[4])
+			irq <= 1'b1;
+		vblank_irq <= 1'b1;
+	end
 
 	// begin of hblank
 	if(stat[3] && (h_cnt == OAM_LEN + 160 + hextra))


### PR DESCRIPTION
Lots os fixes mostly related to timings

T80 is now cycle accurate, (**finally** 🍻 ) passes blargg's instruction and memory timing roms, the DIV timer is now correct (checked with mooneye-gb's div_timing.gb rom) 

the PPU is now aligned with the  CPU and mode 3 is now at least 176 cycles long (should later be changed to use the sprite count per line)

CPU now is unable to write and read to VRAM and OAM in mode 3 and mode 2 and 3 (some games used a write to vram and read from it to check if in mode 3 instead of just reading the mode register ...)

Street Fighter 2 background bug  and Burai Fighter deluxe are fixed and probably others too.

One issue that I thought was related to the LY=LYC interrupt still remains, I compared opcode and PC traces of Super Hunchback (the intro has those glitches) with Gambatte (accurate gb emulator)  and it is a match, so the bug is probably in the LCD Position and Scrolling registers , or how the core handles those.
