### PR TITLE
Quick Fix for the Sprites/Backround Priorities

### DIFF
--- a/hdma.v
+++ b/hdma.v
@@ -20,8 +20,8 @@ module hdma(
 
 );
 
-localparam DELAY_SINGLE = 10;
-localparam DELAY_DOUBLE = DELAY_SINGLE/2;
+localparam DELAY_SINGLE = 5'd10;
+localparam DELAY_DOUBLE = DELAY_SINGLE/5'd2;
 
 //ff51-ff55 HDMA1-5 (GBC)
 reg [7:0] hdma_source_h;		// ff51
@@ -55,7 +55,7 @@ always @(posedge clk) begin
 		hdma_source_l <= 4'hF;
 		hdma_target_h <= 5'h1F;
 		hdma_target_l <= 4'hF;
-      dma_delay <= 4'd0;
+      dma_delay <= 5'd0;
 	end else begin
 	   if(sel_reg && wr) begin
 		
@@ -90,7 +90,7 @@ always @(posedge clk) begin
 			if(hdma_mode==0) begin 				                    //mode 0 GDMA do the transfer in one go after inital delay
              hdma_active <= 1'b1;
 			    if (dma_delay>0) begin
-                dma_delay <= dma_delay - 1;
+                dma_delay <= dma_delay - 5'd1;
 			    end else begin
 					if(hdma_length != 0) begin
 						hdma_rd <= 1'b1;
@@ -134,7 +134,7 @@ always @(posedge clk) begin
 									if(hdma_length != 0) begin
 									  hdma_active <= 1'b1;
 									  if (dma_delay>0) begin
-										  dma_delay <= dma_delay - 1;
+										  dma_delay <= dma_delay - 5'd1;
 									  end else begin
 											hdma_rd <= 1'b1;
 											hdma_cnt <= hdma_cnt + 1'd1;

--- a/video.v
+++ b/video.v
@@ -366,14 +366,25 @@ wire [14:0] sprite_pix = isGBC?{obpd[sprite_palette_index+1][6:0],obpd[sprite_pa
 // - there's a sprite at the current position
 // - the sprites prioroty bit is 0, or
 // - the sprites priority is 1 and the backrgound color is 00
-// - GBC : BG priority is 0 
+// - GBC : BG priority is 0
+// - GBC : BG priority is 1 and the backrgound color is 00
 
 wire bg_piority = isGBC&&stage2_bgp_buffer_pix[stage2_rptr][3];
-	
-wire sprite_pixel_visible = 
-	sprite_pixel_active && lcdc_spr_ena && (~bg_piority) &&
-	((!sprite_pixel_prio) || (stage2_buffer[stage2_rptr] == 2'b00));
-	
+wire [1:0] bg_color = stage2_buffer[stage2_rptr];
+reg sprite_pixel_visible;
+
+always @(*) begin
+	sprite_pixel_visible = 1'b0;
+
+	if (sprite_pixel_active && lcdc_spr_ena) begin		// pixel active and sprites enabled
+		if (bg_color == 2'b00)													// background color = 0
+			sprite_pixel_visible = 1'b1;
+		else if (!bg_piority && !sprite_pixel_prio)   	// sprite has priority enabled and background priority disabled
+			sprite_pixel_visible = 1'b1;
+
+	end
+end
+
 always @(posedge clk) begin
 	if(h_cnt == 455) begin
 		stage2_wptr <= 8'h00;


### PR DESCRIPTION
This fixes Shantae's transparency problems when having a background tile with the priority bit set (probably other games too).

Cleaned up some warnings.