### PR TITLE
Sprite-Sprite Priority fixes for GBC

### DIFF
--- a/sprite.v
+++ b/sprite.v
@@ -41,7 +41,6 @@ module sprite (
 	
 	//gbc
 	output [2:0] pixel_cmap_gbc,
-	output tile_vbank,
 	
 	input oam_wr,
 	input [1:0] oam_addr,
@@ -88,7 +87,6 @@ assign pixel_cmap = flags[4];
 assign pixel_prio = flags[7];
 
 assign pixel_cmap_gbc = flags[2:0];
-assign tile_vbank = flags[3];
 
 reg [7:0] y_pos;
 reg [7:0] x_pos;

--- a/sprite.v
+++ b/sprite.v
@@ -22,6 +22,8 @@
 module sprite (
 	input clk,
 	input size16,
+	input isGBC,
+	input [7:0] sprite_index,
 
 	input [7:0] v_cnt,
 	input [7:0] h_cnt,
@@ -50,7 +52,7 @@ module sprite (
 
 // x position for priority detection. Invisible sprites are far to the right and
 // have minimum priority
-assign x = v_visible?x_pos:8'hff;
+assign x = v_visible?isGBC?sprite_index:x_pos:8'hff;
 
 // register used to store pixel data for current line
 reg [7:0] data0;

--- a/sprites.v
+++ b/sprites.v
@@ -36,8 +36,7 @@ module sprites (
 	
 	//gbc
 	output [2:0] pixel_cmap_gbc,
-	output tile_vbank,
-	
+
 	input sort,
 	input [3:0] index,          // index of sprite which video wants to read data for
 	output [10:0] addr,
@@ -82,7 +81,8 @@ assign oam_do = sprite_oam_do[oam_addr[7:2]];
 
 // address where the sprite wants to read data from
 wire [5:0] sprite_idx_array [SPRITES-1:0];
-wire [5:0] prio_index = sprite_idx_array[index];
+wire [5:0] padded_index = {2'd0,index};
+wire [5:0] prio_index = sprite_idx_array[padded_index];
 assign addr = sprite_addr[prio_index];
 
 //gbc
@@ -116,7 +116,6 @@ for(i=0;i<SPRITES;i=i+1) begin : spr
 		
 	   //gbc
 	   .pixel_cmap_gbc ( sprite_pixel_cmap_gbc[i] ),
-	   .tile_vbank     ( sprite_tile_vbank[i]     ),		
 	
 		.oam_wr   ( oam_wr && (oam_addr[7:2] == i) ),
 		.oam_addr ( oam_addr[1:0] ),
@@ -200,21 +199,6 @@ assign pixel_cmap_gbc =
 	sprite_pixel_active[spr9]?sprite_pixel_cmap_gbc[spr9]:
 	1'b0;
 
-// get the tile vbank of the leftmost sprite
-assign tile_vbank =
-	sprite_pixel_active[spr0]?sprite_tile_vbank[spr0]:
-	sprite_pixel_active[spr1]?sprite_tile_vbank[spr1]:
-	sprite_pixel_active[spr2]?sprite_tile_vbank[spr2]:
-	sprite_pixel_active[spr3]?sprite_tile_vbank[spr3]:
-	sprite_pixel_active[spr4]?sprite_tile_vbank[spr4]:
-	sprite_pixel_active[spr5]?sprite_tile_vbank[spr5]:
-	sprite_pixel_active[spr6]?sprite_tile_vbank[spr6]:
-	sprite_pixel_active[spr7]?sprite_tile_vbank[spr7]:
-	sprite_pixel_active[spr8]?sprite_tile_vbank[spr8]:
-	sprite_pixel_active[spr9]?sprite_tile_vbank[spr9]:
-	1'b0;
-	
-	
 // get the priority of the leftmost sprite
 assign pixel_prio =
 	sprite_pixel_active[spr0]?sprite_pixel_prio[spr0]:

--- a/sprites.v
+++ b/sprites.v
@@ -23,6 +23,7 @@ module sprites (
 	input clk,
 	input clk_reg,
 	input size16,
+	input isGBC,
 
 	// pixel position input which the current pixel is generated for
 	input [7:0] v_cnt,
@@ -98,6 +99,9 @@ for(i=0;i<SPRITES;i=i+1) begin : spr
 	sprite sprite (
 		.clk      ( clk_reg ),
 		.size16   ( size16  ),
+		.isGBC    ( isGBC   ),
+		
+		.sprite_index ( i   ),
 
 		.v_cnt    ( v_cnt   ),
 		.h_cnt    ( h_cnt   ),

--- a/video.v
+++ b/video.v
@@ -81,6 +81,7 @@ sprites sprites (
 	.clk      ( clk          ),
 	.clk_reg  ( clk_reg      ),
 	.size16   ( lcdc_spr_siz ),
+	.isGBC    ( isGBC        ),
 
 	.v_cnt    ( v_cnt        ),
 	.h_cnt    ( h_cnt-STAGE2 ),     // sprites are added in second stage

--- a/video.v
+++ b/video.v
@@ -71,7 +71,6 @@ wire [10:0] sprite_addr;
 
 //gbc
 wire [2:0] sprite_pixel_cmap_gbc;
-wire sprite_tile_vbank;
 
 // "data strobe" for the two bytes each sprite line consists of
 wire [1:0] sprite_dvalid = {
@@ -100,7 +99,6 @@ sprites sprites (
 
 	//gbc
 	.pixel_cmap_gbc ( sprite_pixel_cmap_gbc ),
-	.tile_vbank     ( sprite_tile_vbank     ),
 
 	.oam_wr   ( oam_wr       ),
 	.oam_addr ( oam_addr     ),


### PR DESCRIPTION
This should fix the flickering or missing sprites for GBC, GBC handles those differently than GB , it uses the sprite index in the OAM Region (lower == higher priority) instead of using the horizontal screen position.

This of course should fix a lot of those issues in GBC games (Mario Bros. Intro, Wario land 3, Zelda oracles games, Shantae etc..)