### PR TITLE
Quick fix for sprites when playing a GB game in GBC mode

### DIFF
--- a/sprite.v
+++ b/sprite.v
@@ -22,7 +22,7 @@
 module sprite (
 	input clk,
 	input size16,
-	input isGBC,
+	input isGBC_game,
 	input [7:0] sprite_index,
 
 	input [7:0] v_cnt,
@@ -52,15 +52,15 @@ module sprite (
 
 // x position for priority detection. Invisible sprites are far to the right and
 // have minimum priority
-assign x = v_visible?isGBC?sprite_index:x_pos:8'hff;
+assign x = v_visible?isGBC_game?sprite_index:x_pos:8'hff;
 
 // register used to store pixel data for current line
 reg [7:0] data0;
 reg [7:0] data1;
 
 always @(posedge clk) begin
-	if(ds[0]) data0 <= flags[3]?data_1:data;
-	if(ds[1]) data1 <= flags[3]?data_1:data;
+	if(ds[0]) data0 <= flags[3]&&isGBC_game?data_1:data;
+	if(ds[1]) data1 <= flags[3]&&isGBC_game?data_1:data;
 end
 
 wire [7:0] height = size16?8'd16:8'd8;

--- a/sprites.v
+++ b/sprites.v
@@ -23,7 +23,7 @@ module sprites (
 	input clk,
 	input clk_reg,
 	input size16,
-	input isGBC,
+	input isGBC_game,
 
 	// pixel position input which the current pixel is generated for
 	input [7:0] v_cnt,
@@ -99,7 +99,7 @@ for(i=0;i<SPRITES;i=i+1) begin : spr
 	sprite sprite (
 		.clk      ( clk_reg ),
 		.size16   ( size16  ),
-		.isGBC    ( isGBC   ),
+		.isGBC_game    ( isGBC_game  ),
 		
 		.sprite_index ( i   ),
 

--- a/video.v
+++ b/video.v
@@ -82,7 +82,7 @@ sprites sprites (
 	.clk      ( clk          ),
 	.clk_reg  ( clk_reg      ),
 	.size16   ( lcdc_spr_siz ),
-	.isGBC    ( isGBC&&isGBC_game ),
+	.isGBC_game ( isGBC&&isGBC_game ),
 
 	.v_cnt    ( v_cnt        ),
 	.h_cnt    ( h_cnt-STAGE2 ),     // sprites are added in second stage


### PR DESCRIPTION
* renamed isGBC to isGBC_game   (doesn't matter if it is GBC as long as it is a GB game)
* vram1 should be ignored when it is a GB game

thanks to slingshot for catching this one