### PR TITLE
T80: ignore/skip byte after a stop opcode

### DIFF
--- a/rtl/T80/T80_MCode.vhd
+++ b/rtl/T80/T80_MCode.vhd
@@ -1170,9 +1170,15 @@ begin
 		when "11101001" =>
 			-- JP (HL)
 			JumpXY <= '1';
-		when "00010000" =>
-			if Mode = 3 then
+		when "00010000" =>  
+			if Mode = 3 then -- STOP and skip next byte
+				MCycles <= "010";
 				I_DJNZ <= '1';
+				case to_integer(unsigned(MCycle)) is
+				when 2 =>
+					Inc_PC <= '1';
+				when others => null;
+				end case;
 			elsif Mode < 2 then
 				-- DJNZ,e
 				MCycles <= "011";


### PR DESCRIPTION
This fixes the Konami Collection Games (2 and 4), both have a corrupted stop opcode when switching to fast mode (good job finding that out @paulb-nl  )

![unknown](https://user-images.githubusercontent.com/407195/85156284-c545c300-b251-11ea-8710-587c5b2617c8.png)
