### PR TITLE
More APU fixes

### DIFF
--- a/rtl/gb.v
+++ b/rtl/gb.v
@@ -90,8 +90,8 @@ wire sel_if   = cpu_addr == 16'hff0f;                // interupt flag
 wire sel_iram = (cpu_addr[15:14] == 2'b11) && (~&cpu_addr[13:9]); // 8k internal ram at $C000-DFFF. C000-DDFF mirrored to E000-FDFF
 wire sel_zpram = (cpu_addr[15:7] == 9'b111111111) && // 127 bytes zero pageram at $ff80
 					 (cpu_addr != 16'hffff);
-wire sel_audio = (cpu_addr[15:8] == 8'hff) &&        // audio reg ff10 - ff3f
-					((cpu_addr[7:5] == 3'b001) || (cpu_addr[7:4] == 4'b0001));
+wire sel_audio = (cpu_addr[15:8] == 8'hff) &&        // audio reg ff10 - ff3f and ff76/ff77 PCM12/PCM34 (undocumented registers)
+					((cpu_addr[7:5] == 3'b001) || (cpu_addr[7:4] == 4'b0001) || (cpu_addr[7:0] == 8'h76) || (cpu_addr[7:0] == 8'h77));
 					
 //DMA can select from $0000 to $F100					
 wire dma_sel_rom = !dma_addr[15];                       // lower 32k are rom
@@ -247,7 +247,7 @@ gbc_snd audio (
 
 	.s1_read  		( audio_rd  		),
 	.s1_write 		( audio_wr  		),
-	.s1_addr    	( cpu_addr[5:0]	),
+	.s1_addr    	( cpu_addr[6:0]	),
    .s1_readdata 	( audio_do        ),
 	.s1_writedata  ( cpu_do       	),
 

--- a/rtl/gb.v
+++ b/rtl/gb.v
@@ -155,13 +155,19 @@ wire ce_cpu = cpu_speed ? ce_2x:ce;
 wire clk_cpu = clk_sys & ce_cpu;
 
 wire cpu_clken = !(isGBC && hdma_active) && ce_cpu;  //when hdma is enabled stop CPU (GBC)
+reg reset_r = 1;
+
+//sync reset with clock
+always  @ (posedge clk) begin
+	reset_r <= reset;
+end
 
 
 wire cpu_stop;
 
 	
 GBse cpu (
-	.RESET_n    ( !reset        ),
+	.RESET_n    ( !reset_r        ),
 	.CLK_n      ( clk_sys       ),
 	.CLKEN      ( cpu_clken     ),
 	.WAIT_n     ( 1'b1          ),
@@ -210,7 +216,7 @@ reg prepare_switch; // set to 1 to toggle speed
 assign speed = cpu_speed;
 
 always @(posedge clk_sys) begin
-   if(reset) begin
+   if(reset_r) begin
 		cpu_speed <= 1'b0;
 		prepare_switch <= 1'b0;
 	end
@@ -235,7 +241,7 @@ wire [7:0] audio_do;
 gbc_snd audio (
 	.clk				( clk_sys			),
 	.ce            ( ce_2x           ),
-	.reset			( reset				),
+	.reset			( reset_r				),
 	
 	.is_gbc        ( isGBC           ),
 
@@ -268,7 +274,7 @@ assign sc_int_clock2 = sc_shiftclock;
 
 link link (
   .clk(clk_cpu),
-  .rst(reset),
+  .rst(reset_r),
 
   .sel_sc(sel_sc),
   .sel_sb(sel_sb),
@@ -299,7 +305,7 @@ always @(posedge clk_cpu) begin
 	reg [8:0] serial_clk_div; //8192Hz
 
 	serial_irq_f <= 1'b0;
-   if(reset) begin
+   if(reset_r) begin
 		  sc_start_f <= 1'b0;
 		  sc_shiftclock_f <= 1'b0;
 	end else if (sel_sc && !cpu_wr_n) begin	 //cpu write
@@ -334,7 +340,7 @@ end
 reg  [1:0] p54;
 
 always @(posedge clk_cpu) begin
-	if(reset) p54 <= 2'b11;
+	if(reset_r) p54 <= 2'b11;
 	else if(sel_joy && !cpu_wr_n)	p54 <= cpu_do[5:4];
 end
 
@@ -374,7 +380,7 @@ reg old_vblank_irq, old_video_irq, old_timer_irq, old_serial_irq;
 always @(negedge clk_cpu) begin //negedge to trigger interrupt earlier
 	reg old_ack = 0;
 	
-	if(reset) begin
+	if(reset_r) begin
 		ie_r <= 5'h00;
 		if_r <= 5'h00;
 	end
@@ -430,7 +436,7 @@ end
 wire timer_irq;
 wire [7:0] timer_do;
 timer timer (
-	.reset	    ( reset         ),
+	.reset	    ( reset_r         ),
 	.clk		    ( clk_cpu       ), //2x in fast mode
 
 	.irq         ( timer_irq     ),
@@ -456,7 +462,7 @@ wire [7:0] dma_data = dma_sel_iram?iram_do:dma_sel_vram?(isGBC&&vram_bank)?vram1
 
 
 video video (
-	.reset       ( reset         ),
+	.reset       ( reset_r         ),
 	.clk         ( clk_sys       ),
 	.ce          ( ce            ),   // 4Mhz
 	.ce_cpu      ( ce_cpu        ),   //can be 2x in cgb double speed mode
@@ -547,7 +553,7 @@ wire hdma_rd;
 wire hdma_active;
 
 hdma hdma(
-	.reset	          ( reset         ),
+	.reset	          ( reset_r         ),
 	.clk		          ( clk_sys       ),
 	.ce                ( ce_cpu         ),
 	.speed				 ( cpu_speed     ),
@@ -614,7 +620,7 @@ spram #(15) iram (
 
 //GBC WRAM banking
 always @(posedge clk_cpu) begin
-	if(reset)
+	if(reset_r)
 		iram_bank <= 3'd1;
 	else if((cpu_addr == 16'hff70) && !cpu_wr_n && isGBC) begin
 		if (cpu_do[2:0]==3'd0) // 0 -> 1;
@@ -631,7 +637,7 @@ end
 // writing 01(GB) or 11(GBC) to $ff50 disables the internal rom
 reg boot_rom_enabled;
 always @(posedge clk) begin
-	if(reset)
+	if(reset_r)
 		boot_rom_enabled <= 1'b1;
 	else if((cpu_addr == 16'hff50) && !cpu_wr_n)
           if ((isGBC && cpu_do[7:0]==8'h11) || (!isGBC && cpu_do[0]))

--- a/rtl/gbc_snd.vhd
+++ b/rtl/gbc_snd.vhd
@@ -808,12 +808,14 @@ begin
         variable sweep_update    : boolean;
         variable sweep_negate    : boolean;
         variable sq1_envoff      : boolean; -- check if envelope is on (zombiemode)
+        variable sq1_sduty       : std_logic_vector(1 downto 0); -- Sq1 duty cycle shadow register
 
         variable sq2_fcnt        : unsigned(10 downto 0);
         variable sq2_phase       : integer range 0 to 7;
         variable sq2_len         : std_logic_vector(6 downto 0);
         variable sq2_envcnt      : std_logic_vector(3 downto 0); -- Sq2 envelope timer count
         variable sq2_envoff      : boolean;                      -- check if envelope is on (zombiemode)
+        variable sq2_sduty       : std_logic_vector(1 downto 0); -- Sq2 duty cycle shadow register
 
         variable wav_fcnt        : unsigned(10 downto 0);
         variable wav_len         : std_logic_vector(8 downto 0);
@@ -874,6 +876,9 @@ begin
             
             sq1_suppressed <= '1';
             sq2_suppressed <= '1';
+
+            sq1_sduty    := (others => '0');
+            sq2_sduty    := (others => '0');
 
             wav_playing <= '0';
             wav_fcnt    := (others => '0');
@@ -948,12 +953,13 @@ begin
                                 sq1_suppressed <= '0';
                                 sq1_phase := sq1_phase + 1;
                                 sq1_fcnt := unsigned(sq1_freq);
+                                sq1_sduty := sq1_duty; -- only change duty after the sample is finished
                             else
                                 sq1_fcnt := acc_fcnt(sq1_fcnt'range);
                             end if;
                         end if;
 
-                        case sq1_duty is
+                        case sq1_sduty is
                             when "00"   => sq1_out <= duty_0(sq1_phase);
                             when "01"   => sq1_out <= duty_1(sq1_phase);
                             when "10"   => sq1_out <= duty_2(sq1_phase);
@@ -1161,12 +1167,13 @@ begin
                                 sq2_suppressed <= '0';
                                 sq2_phase := sq2_phase + 1;
                                 sq2_fcnt := unsigned(sq2_freq);
+                                sq2_sduty := sq2_duty;  -- only change duty after the sample is finished
                             else
                                 sq2_fcnt := acc_fcnt(sq2_fcnt'range);
                             end if;
                         end if;
 
-                        case sq2_duty is
+                        case sq2_sduty is
                             when "00"   => sq2_out <= duty_0(sq2_phase);
                             when "01"   => sq2_out <= duty_1(sq2_phase);
                             when "10"   => sq2_out <= duty_2(sq2_phase);
@@ -1513,6 +1520,9 @@ begin
 
                     sq1_suppressed <= '1';
                     sq2_suppressed <= '1';
+
+                    sq1_sduty    := (others => '0');
+                    sq2_sduty    := (others => '0');
         
                     wav_playing <= '0';
                     wav_fcnt    := (others => '0');

--- a/rtl/gbc_snd.vhd
+++ b/rtl/gbc_snd.vhd
@@ -625,7 +625,7 @@ begin
     process (s1_addr, sq1_swper, sq1_swdir, sq1_swshift, sq1_duty, sq1_svol, sq1_envsgn, sq1_envper, sq1_lenchk,
         noi_playing, wav_playing, sq2_playing, sq1_playing, wav_enable, wav_volsh, wav_ram, wav_index, wav_access,
         sq2_duty, sq2_svol, sq2_envsgn, sq2_envper, sq2_lenchk, snd_enable, wav_lenchk, noi_svol, noi_envsgn, noi_envper,
-        noi_freqsh, noi_short, noi_div, noi_lenchk, ch_vol, ch_map, is_gbc)
+        noi_freqsh, noi_short, noi_div, noi_lenchk, ch_vol, ch_map, is_gbc, sq1_vol, sq2_vol, wav_wav, noi_vol)
         variable wave_index_read : std_logic_vector(3 downto 0);
     begin
         case s1_addr is
@@ -728,6 +728,34 @@ begin
                 s1_readdata <= ch_vol; -- NR50 FF24
             when "0100101" =>
                 s1_readdata <= ch_map; -- NR51 FF25
+            
+                -- Undocumented Registers
+            when "1110110"  =>         -- PCM12 FF76
+                  if is_gbc = '1' then
+                    s1_readdata <= (others => '0');
+                    if  sq2_playing = '1' then
+                        s1_readdata(7 downto 4) <= sq2_vol;
+                    end if;
+                    if  sq1_playing = '1' then
+                        s1_readdata(3 downto 0) <= sq1_vol;
+                    end if;
+                  else
+                    s1_readdata <= X"FF";
+                  end if;
+            when "1110111"  =>         -- PCM34 FF77
+                  if is_gbc = '1' then
+                    s1_readdata <= (others => '0');
+                    if  noi_playing = '1' then
+                        s1_readdata(7 downto 4) <= noi_vol;
+                    end if;
+                    if  wav_playing = '1' then
+                        s1_readdata(3 downto 0) <= wav_wav(5 downto 2);  
+                    end if;
+                  else
+                    s1_readdata <= X"FF";
+                  end if;
+
+            
             when others =>
                 s1_readdata <= X"FF";
         end case;

--- a/rtl/gbc_snd.vhd
+++ b/rtl/gbc_snd.vhd
@@ -14,7 +14,7 @@ entity gbc_snd is
 
         s1_read      : in std_logic;
         s1_write     : in std_logic;
-        s1_addr      : in std_logic_vector(5 downto 0);
+        s1_addr      : in std_logic_vector(6 downto 0);
         s1_readdata  : out std_logic_vector(7 downto 0);
         s1_writedata : in std_logic_vector(7 downto 0);
 
@@ -367,23 +367,23 @@ begin
                 end if;
                 
                 -- write to registers ignored when the apu is off , Wave memory can be read back freely , NR52 power control is always writable 
-                if s1_write = '1' and (snd_enable = '1' or s1_addr = "100110" or s1_addr(5 downto 4) = "11" or (is_gbc = '0' and (s1_addr = "010001" or  s1_addr = "010110" or s1_addr = "011011" or s1_addr = "100000" ))) then
+                if s1_write = '1' and (snd_enable = '1' or s1_addr = "0100110" or s1_addr(5 downto 4) = "11" or (is_gbc = '0' and (s1_addr = "0010001" or  s1_addr = "0010110" or s1_addr = "0011011" or s1_addr = "0100000" ))) then
                     case s1_addr is
                             -- Square 1
-                        when "010000" => -- NR10 FF10 -PPP NSSS Sweep period, negate, shift
+                        when "0010000" => -- NR10 FF10 -PPP NSSS Sweep period, negate, shift
                             sq1_swper <= s1_writedata(6 downto 4);
                             if s1_writedata(3) = '0' then -- only neg to pos, 1 -> 0
                                 sq1_swdir_change <= '1';
                             end if;
                             sq1_swdir   <= s1_writedata(3);
                             sq1_swshift <= s1_writedata(2 downto 0);
-                        when "010001" => -- NR11 FF11 DDLL LLLL Duty, Length load (64-L)
+                        when "0010001" => -- NR11 FF11 DDLL LLLL Duty, Length load (64-L)
                             if snd_enable = '1' then
                                 sq1_duty      <= s1_writedata(7 downto 6);
                             end if;
                             sq1_slen      <= std_logic_vector("1000000" - unsigned(s1_writedata(5 downto 0)));
                             sq1_lenchange <= '1';
-                        when "010010" => -- NR12 FF12 VVVV APPP Starting volume, Envelope add mode, period
+                        when "0010010" => -- NR12 FF12 VVVV APPP Starting volume, Envelope add mode, period
                             -- zombie mode copy old values
                             sq1_envsgn_old <= sq1_envsgn;
                             sq1_envper_old <= sq1_envper;
@@ -392,9 +392,9 @@ begin
                             sq1_svol       <= s1_writedata(7 downto 4);
                             sq1_envsgn     <= s1_writedata(3);
                             sq1_envper     <= s1_writedata(2 downto 0);
-                        when "010011" => -- NR13 FF13 FFFF FFFF Frequency LSB
+                        when "0010011" => -- NR13 FF13 FFFF FFFF Frequency LSB
                             sq1_freq(7 downto 0) <= s1_writedata;
-                        when "010100" => -- NR14 FF14 TL-- -FFF Trigger, Length enable, Frequency MSB
+                        when "0010100" => -- NR14 FF14 TL-- -FFF Trigger, Length enable, Frequency MSB
                             sq1_trigger <= s1_writedata(7);
                             if sq1_lenchk = '0' and s1_writedata(6) = '1' and en_len_r then
                                 sq1_lenquirk <= '1';
@@ -403,13 +403,13 @@ begin
                             sq1_freq(10 downto 8) <= s1_writedata(2 downto 0);
 
                             -- Square 2
-                        when "010110" => -- NR21 FF16 DDLL LLLL Duty, Length load (64-L)
+                        when "0010110" => -- NR21 FF16 DDLL LLLL Duty, Length load (64-L)
                             if snd_enable = '1' then
                                 sq2_duty      <= s1_writedata(7 downto 6);
                             end if;
                             sq2_slen      <= std_logic_vector("1000000" - unsigned(s1_writedata(5 downto 0)));
                             sq2_lenchange <= '1';
-                        when "010111" => -- NR22 FF17 VVVV APPP Starting volume, Envelope add mode, period
+                        when "0010111" => -- NR22 FF17 VVVV APPP Starting volume, Envelope add mode, period
                             -- zombie mode copy old values
                             sq2_envsgn_old <= sq2_envsgn;
                             sq2_envper_old <= sq2_envper;
@@ -418,9 +418,9 @@ begin
                             sq2_nr2change  <= '1';
                             sq2_envsgn     <= s1_writedata(3);
                             sq2_envper     <= s1_writedata(2 downto 0);
-                        when "011000" => -- NR23 FF18 FFFF FFFF Frequency LSB
+                        when "0011000" => -- NR23 FF18 FFFF FFFF Frequency LSB
                             sq2_freq(7 downto 0) <= s1_writedata;
-                        when "011001" => -- NR24 FF19 TL-- -FFF Trigger, Length enable, Frequency MSB
+                        when "0011001" => -- NR24 FF19 TL-- -FFF Trigger, Length enable, Frequency MSB
                             sq2_trigger <= s1_writedata(7);
                             if sq2_lenchk = '0' and s1_writedata(6) = '1' and en_len_r then
                                 sq2_lenquirk <= '1';
@@ -429,17 +429,17 @@ begin
                             sq2_freq(10 downto 8) <= s1_writedata(2 downto 0);
 
                             -- Wave
-                        when "011010" => -- NR30 FF1A E--- ---- DAC power
+                        when "0011010" => -- NR30 FF1A E--- ---- DAC power
                             wav_enable <= s1_writedata(7);
-                        when "011011" => -- NR31 FF1B LLLL LLLL Length load (256-L)
+                        when "0011011" => -- NR31 FF1B LLLL LLLL Length load (256-L)
                             -- wav_slen <= s1_writedata;
                             wav_slen      <= std_logic_vector("100000000" - unsigned(s1_writedata));
                             wav_lenchange <= '1';
-                        when "011100" => -- NR32 FF1C -VV- ---- Volume code (00=0%, 01=100%, 10=50%, 11=25%)
+                        when "0011100" => -- NR32 FF1C -VV- ---- Volume code (00=0%, 01=100%, 10=50%, 11=25%)
                             wav_volsh <= s1_writedata(6 downto 5);
-                        when "011101" => -- NR33 FF1D FFFF FFFF Frequency LSB
+                        when "0011101" => -- NR33 FF1D FFFF FFFF Frequency LSB
                             wav_freq(7 downto 0) <= s1_writedata;
-                        when "011110" => -- NR34 FF1E TL-- -FFF Trigger, Length enable, Frequency MSB
+                        when "0011110" => -- NR34 FF1E TL-- -FFF Trigger, Length enable, Frequency MSB
                             wav_trigger <= s1_writedata(7);
                             if s1_writedata(7) = '1' then
                                 wav_trigger_cnt := "1001";
@@ -451,10 +451,10 @@ begin
                             wav_freq(10 downto 8) <= s1_writedata(2 downto 0);
 
                             -- Noise
-                        when "100000" => -- NR41 FF20 --LL LLLL Length load (64-L)
+                        when "0100000" => -- NR41 FF20 --LL LLLL Length load (64-L)
                             noi_slen      <= std_logic_vector("1000000" - unsigned(s1_writedata(5 downto 0)));
                             noi_lenchange <= '1';
-                        when "100001" => -- NR42 FF21 VVVV APPP Starting volume, Envelope add mode, period
+                        when "0100001" => -- NR42 FF21 VVVV APPP Starting volume, Envelope add mode, period
                             -- zombie mode copy old values
                             noi_envsgn_old <= noi_envsgn;
                             noi_envper_old <= noi_envper;
@@ -463,12 +463,12 @@ begin
                             noi_nr2change  <= '1';
                             noi_envsgn     <= s1_writedata(3);
                             noi_envper     <= s1_writedata(2 downto 0);
-                        when "100010" => -- NR43 FF22 SSSS WDDD Clock shift, Width mode of LFSR, Divisor code
+                        when "0100010" => -- NR43 FF22 SSSS WDDD Clock shift, Width mode of LFSR, Divisor code
                             noi_freqsh     <= s1_writedata(7 downto 4);
                             noi_short      <= s1_writedata(3);
                             noi_div        <= s1_writedata(2 downto 0);
                             noi_freqchange <= '1';
-                        when "100011" => -- NR44 FF23 TL-- ---- Trigger, Length enable
+                        when "0100011" => -- NR44 FF23 TL-- ---- Trigger, Length enable
                             noi_trigger <= s1_writedata(7);
                             if noi_lenchk = '0' and s1_writedata(6) = '1' and en_len_r then
                                 noi_lenquirk <= '1';
@@ -476,61 +476,61 @@ begin
                             noi_lenchk              <= s1_writedata(6);
 
                             -- Control/Status
-                        when "100100" => ch_vol <= s1_writedata; -- NR50 FF24
-                        when "100101" => ch_map <= s1_writedata; -- NR51 FF25
+                        when "0100100" => ch_vol <= s1_writedata; -- NR50 FF24
+                        when "0100101" => ch_map <= s1_writedata; -- NR51 FF25
                             --
                             -- Wave Table
-                        when "110000" =>                         --      FF30 0000 1111 Samples 0 and 1
+                        when "0110000" =>                         --      FF30 0000 1111 Samples 0 and 1
                             wav_ram(0) <= s1_writedata(7 downto 4);
                             wav_ram(1) <= s1_writedata(3 downto 0);
-                        when "110001" => --      FF31 0000 1111 Samples 2 and 3
+                        when "0110001" => --      FF31 0000 1111 Samples 2 and 3
                             wav_ram(2) <= s1_writedata(7 downto 4);
                             wav_ram(3) <= s1_writedata(3 downto 0);
-                        when "110010" => --      FF32 0000 1111 Samples 4 and 5
+                        when "0110010" => --      FF32 0000 1111 Samples 4 and 5
                             wav_ram(4) <= s1_writedata(7 downto 4);
                             wav_ram(5) <= s1_writedata(3 downto 0);
-                        when "110011" => --      FF33 0000 1111 Samples 6 and 31
+                        when "0110011" => --      FF33 0000 1111 Samples 6 and 31
                             wav_ram(6) <= s1_writedata(7 downto 4);
                             wav_ram(7) <= s1_writedata(3 downto 0);
-                        when "110100" => --      FF34 0000 1111 Samples 8 and 31
+                        when "0110100" => --      FF34 0000 1111 Samples 8 and 31
                             wav_ram(8) <= s1_writedata(7 downto 4);
                             wav_ram(9) <= s1_writedata(3 downto 0);
-                        when "110101" => --      FF35 0000 1111 Samples 10 and 11
+                        when "0110101" => --      FF35 0000 1111 Samples 10 and 11
                             wav_ram(10) <= s1_writedata(7 downto 4);
                             wav_ram(11) <= s1_writedata(3 downto 0);
-                        when "110110" => --      FF36 0000 1111 Samples 12 and 13
+                        when "0110110" => --      FF36 0000 1111 Samples 12 and 13
                             wav_ram(12) <= s1_writedata(7 downto 4);
                             wav_ram(13) <= s1_writedata(3 downto 0);
-                        when "110111" => --      FF37 0000 1111 Samples 14 and 15
+                        when "0110111" => --      FF37 0000 1111 Samples 14 and 15
                             wav_ram(14) <= s1_writedata(7 downto 4);
                             wav_ram(15) <= s1_writedata(3 downto 0);
-                        when "111000" => --      FF38 0000 1111 Samples 16 and 17
+                        when "0111000" => --      FF38 0000 1111 Samples 16 and 17
                             wav_ram(16) <= s1_writedata(7 downto 4);
                             wav_ram(17) <= s1_writedata(3 downto 0);
-                        when "111001" => --      FF39 0000 1111 Samples 18 and 19
+                        when "0111001" => --      FF39 0000 1111 Samples 18 and 19
                             wav_ram(18) <= s1_writedata(7 downto 4);
                             wav_ram(19) <= s1_writedata(3 downto 0);
-                        when "111010" => --      FF3A 0000 1111 Samples 20 and 21
+                        when "0111010" => --      FF3A 0000 1111 Samples 20 and 21
                             wav_ram(20) <= s1_writedata(7 downto 4);
                             wav_ram(21) <= s1_writedata(3 downto 0);
-                        when "111011" => --      FF3B 0000 1111 Samples 22 and 23
+                        when "0111011" => --      FF3B 0000 1111 Samples 22 and 23
                             wav_ram(22) <= s1_writedata(7 downto 4);
                             wav_ram(23) <= s1_writedata(3 downto 0);
-                        when "111100" => --      FF3C 0000 1111 Samples 24 and 25
+                        when "0111100" => --      FF3C 0000 1111 Samples 24 and 25
                             wav_ram(24) <= s1_writedata(7 downto 4);
                             wav_ram(25) <= s1_writedata(3 downto 0);
-                        when "111101" => --      FF3D 0000 1111 Samples 26 and 27
+                        when "0111101" => --      FF3D 0000 1111 Samples 26 and 27
                             wav_ram(26) <= s1_writedata(7 downto 4);
                             wav_ram(27) <= s1_writedata(3 downto 0);
-                        when "111110" => --      FF3E 0000 1111 Samples 28 and 29
+                        when "0111110" => --      FF3E 0000 1111 Samples 28 and 29
                             wav_ram(28) <= s1_writedata(7 downto 4);
                             wav_ram(29) <= s1_writedata(3 downto 0);
-                        when "111111" => --      FF3F 0000 1111 Samples 30 and 31
+                        when "0111111" => --      FF3F 0000 1111 Samples 30 and 31
                             wav_ram(30) <= s1_writedata(7 downto 4);
                             wav_ram(31) <= s1_writedata(3 downto 0);
 
                         -- NR52 FF26 P--- NW21 Power control/status, Channel length statuses
-                        when "100110" => 
+                        when "0100110" => 
                             -- TODO: maybe check if event on poweroff or poweron
                             snd_enable <= s1_writedata(7);
                             if s1_writedata(7) = '0' then
@@ -601,54 +601,54 @@ begin
     begin
         case s1_addr is
                 -- Square 1
-            when "010000" => -- NR10 FF10 -PPP NSSS Sweep period, negate, shift
+            when "0010000" => -- NR10 FF10 -PPP NSSS Sweep period, negate, shift
                 s1_readdata <= '1' & sq1_swper & sq1_swdir & sq1_swshift;
-            when "010001" => -- NR11 FF11 DDLL LLLL Duty, Length load (64-L)
+            when "0010001" => -- NR11 FF11 DDLL LLLL Duty, Length load (64-L)
                 s1_readdata <= sq1_duty & "111111";
-            when "010010" => -- NR12 FF12 VVVV APPP Starting volume, Envelope add mode, period
+            when "0010010" => -- NR12 FF12 VVVV APPP Starting volume, Envelope add mode, period
                 s1_readdata <= sq1_svol & sq1_envsgn & sq1_envper;
-            when "010011" => -- NR13 FF13 FFFF FFFF Frequency LSB
+            when "0010011" => -- NR13 FF13 FFFF FFFF Frequency LSB
                 s1_readdata <= X"FF";
-            when "010100" => -- NR14 FF14 TL-- -FFF Trigger, Length enable, Frequency MSB
+            when "0010100" => -- NR14 FF14 TL-- -FFF Trigger, Length enable, Frequency MSB
                 s1_readdata <= '1' & sq1_lenchk & "111111";
 
                 -- Square 2
-            when "010110" => -- NR21 FF16 DDLL LLLL Duty, Length load (64-L)
+            when "0010110" => -- NR21 FF16 DDLL LLLL Duty, Length load (64-L)
                 s1_readdata <= sq2_duty & "111111";
-            when "010111" => -- NR22 FF17 VVVV APPP Starting volume, Envelope add mode, period
+            when "0010111" => -- NR22 FF17 VVVV APPP Starting volume, Envelope add mode, period
                 s1_readdata <= sq2_svol & sq2_envsgn & sq2_envper;
-            when "011000" => -- NR23 FF18 FFFF FFFF Frequency LSB
+            when "0011000" => -- NR23 FF18 FFFF FFFF Frequency LSB
                 s1_readdata <= X"FF";
-            when "011001" => -- NR24 FF19 TL-- -FFF Trigger, Length enable, Frequency MSB
+            when "0011001" => -- NR24 FF19 TL-- -FFF Trigger, Length enable, Frequency MSB
                 s1_readdata <= '1' & sq2_lenchk & "111111";
 
-            when "100110" => -- NR52 FF26 P--- NW21 Power control/status, Channel length statuses
+            when "0100110" => -- NR52 FF26 P--- NW21 Power control/status, Channel length statuses
                 s1_readdata <= snd_enable & "111" & noi_playing & wav_playing & sq2_playing & sq1_playing;
 
                 -- Wave
-            when "011010" => -- NR30 FF1A E--- ---- DAC power
+            when "0011010" => -- NR30 FF1A E--- ---- DAC power
                 s1_readdata <= wav_enable & "1111111";
-            when "011011" => -- NR31 FF1B LLLL LLLL Length load (256-L)
+            when "0011011" => -- NR31 FF1B LLLL LLLL Length load (256-L)
                 s1_readdata <= X"FF";
-            when "011100" => -- NR32 FF1C -VV- ---- Volume code (00=0%, 01=100%, 10=50%, 11=25%)
+            when "0011100" => -- NR32 FF1C -VV- ---- Volume code (00=0%, 01=100%, 10=50%, 11=25%)
                 s1_readdata <= '1' & wav_volsh & "11111";
-            when "011101" => -- NR33 FF1D FFFF FFFF Frequency LSB
+            when "0011101" => -- NR33 FF1D FFFF FFFF Frequency LSB
                 s1_readdata <= X"FF";
-            when "011110" => -- NR34 FF1E TL-- -FFF Trigger, Length enable, Frequency MSB
+            when "0011110" => -- NR34 FF1E TL-- -FFF Trigger, Length enable, Frequency MSB
                 s1_readdata <= '1' & wav_lenchk & "111111";
 
                 -- Noise
-            when "100000" => -- NR41 FF20 --LL LLLL Length load (64-L)
+            when "0100000" => -- NR41 FF20 --LL LLLL Length load (64-L)
                 s1_readdata <= X"FF";
-            when "100001" => -- NR42 FF21 VVVV APPP Starting volume, Envelope add mode, period
+            when "0100001" => -- NR42 FF21 VVVV APPP Starting volume, Envelope add mode, period
                 s1_readdata <= noi_svol & noi_envsgn & noi_envper;
-            when "100010" => -- NR43 FF22 SSSS WDDD Clock shift, Width mode of LFSR, Divisor code
+            when "0100010" => -- NR43 FF22 SSSS WDDD Clock shift, Width mode of LFSR, Divisor code
                 s1_readdata <= noi_freqsh & noi_short & noi_div;
-            when "100011" => -- NR44 FF23 TL-- ---- Trigger, Length enable
+            when "0100011" => -- NR44 FF23 TL-- ---- Trigger, Length enable
                 s1_readdata <= '1' & noi_lenchk & "111111";
 
                 -- Wave Table
-            when "110000" | "110001" | "110010" | "110011" | "110100" | "110101" | "110110" | "110111" | "111000" | "111001" | "111010" | "111011" | "111100" | "111101" | "111110" | "111111" => -- FF30 to FF3F
+            when "0110000" | "0110001" | "0110010" | "0110011" | "0110100" | "0110101" | "0110110" | "0110111" | "0111000" | "0111001" | "0111010" | "0111011" | "0111100" | "0111101" | "0111110" | "0111111" => -- FF30 to FF3F
                 if wav_playing = '1' then
                     wave_index_read := std_logic_vector(wav_index(4 downto 1));
                 else
@@ -695,9 +695,9 @@ begin
                 end if;
 
                 -- Control/Status
-            when "100100" =>
+            when "0100100" =>
                 s1_readdata <= ch_vol; -- NR50 FF24
-            when "100101" =>
+            when "0100101" =>
                 s1_readdata <= ch_map; -- NR51 FF25
             when others =>
                 s1_readdata <= X"FF";

--- a/rtl/gbc_snd.vhd
+++ b/rtl/gbc_snd.vhd
@@ -229,6 +229,7 @@ begin
         variable sq1_trigger_cnt : unsigned(2 downto 0);
         variable sq2_trigger_cnt : unsigned(2 downto 0);
         variable wav_trigger_cnt : unsigned(3 downto 0);
+        variable wave_index_write : std_logic_vector(3 downto 0);
     begin
 
         -- Registers
@@ -520,56 +521,67 @@ begin
                             -- Control/Status
                         when "0100100" => ch_vol <= s1_writedata; -- NR50 FF24
                         when "0100101" => ch_map <= s1_writedata; -- NR51 FF25
-                            --
+
                             -- Wave Table
-                        when "0110000" =>                         --      FF30 0000 1111 Samples 0 and 1
-                            wav_ram(0) <= s1_writedata(7 downto 4);
-                            wav_ram(1) <= s1_writedata(3 downto 0);
-                        when "0110001" => --      FF31 0000 1111 Samples 2 and 3
-                            wav_ram(2) <= s1_writedata(7 downto 4);
-                            wav_ram(3) <= s1_writedata(3 downto 0);
-                        when "0110010" => --      FF32 0000 1111 Samples 4 and 5
-                            wav_ram(4) <= s1_writedata(7 downto 4);
-                            wav_ram(5) <= s1_writedata(3 downto 0);
-                        when "0110011" => --      FF33 0000 1111 Samples 6 and 31
-                            wav_ram(6) <= s1_writedata(7 downto 4);
-                            wav_ram(7) <= s1_writedata(3 downto 0);
-                        when "0110100" => --      FF34 0000 1111 Samples 8 and 31
-                            wav_ram(8) <= s1_writedata(7 downto 4);
-                            wav_ram(9) <= s1_writedata(3 downto 0);
-                        when "0110101" => --      FF35 0000 1111 Samples 10 and 11
-                            wav_ram(10) <= s1_writedata(7 downto 4);
-                            wav_ram(11) <= s1_writedata(3 downto 0);
-                        when "0110110" => --      FF36 0000 1111 Samples 12 and 13
-                            wav_ram(12) <= s1_writedata(7 downto 4);
-                            wav_ram(13) <= s1_writedata(3 downto 0);
-                        when "0110111" => --      FF37 0000 1111 Samples 14 and 15
-                            wav_ram(14) <= s1_writedata(7 downto 4);
-                            wav_ram(15) <= s1_writedata(3 downto 0);
-                        when "0111000" => --      FF38 0000 1111 Samples 16 and 17
-                            wav_ram(16) <= s1_writedata(7 downto 4);
-                            wav_ram(17) <= s1_writedata(3 downto 0);
-                        when "0111001" => --      FF39 0000 1111 Samples 18 and 19
-                            wav_ram(18) <= s1_writedata(7 downto 4);
-                            wav_ram(19) <= s1_writedata(3 downto 0);
-                        when "0111010" => --      FF3A 0000 1111 Samples 20 and 21
-                            wav_ram(20) <= s1_writedata(7 downto 4);
-                            wav_ram(21) <= s1_writedata(3 downto 0);
-                        when "0111011" => --      FF3B 0000 1111 Samples 22 and 23
-                            wav_ram(22) <= s1_writedata(7 downto 4);
-                            wav_ram(23) <= s1_writedata(3 downto 0);
-                        when "0111100" => --      FF3C 0000 1111 Samples 24 and 25
-                            wav_ram(24) <= s1_writedata(7 downto 4);
-                            wav_ram(25) <= s1_writedata(3 downto 0);
-                        when "0111101" => --      FF3D 0000 1111 Samples 26 and 27
-                            wav_ram(26) <= s1_writedata(7 downto 4);
-                            wav_ram(27) <= s1_writedata(3 downto 0);
-                        when "0111110" => --      FF3E 0000 1111 Samples 28 and 29
-                            wav_ram(28) <= s1_writedata(7 downto 4);
-                            wav_ram(29) <= s1_writedata(3 downto 0);
-                        when "0111111" => --      FF3F 0000 1111 Samples 30 and 31
-                            wav_ram(30) <= s1_writedata(7 downto 4);
-                            wav_ram(31) <= s1_writedata(3 downto 0);
+                        when "0110000" | "0110001" | "0110010" | "0110011" | "0110100" | "0110101" | "0110110" | "0110111" | "0111000" | "0111001" | "0111010" | "0111011" | "0111100" | "0111101" | "0111110" | "0111111" => -- FF30 to FF3F
+                            if wav_playing = '1' then
+                                wave_index_write := std_logic_vector(wav_index(4 downto 1));
+                            else
+                                wave_index_write := s1_addr(3 downto 0);
+                            end if;
+            
+                            if is_gbc = '1' or wav_access > 0 or wav_playing = '0' then
+                                case wave_index_write is
+                                when "0000" => --      FF30 0000 1111 Samples 0 and 1
+                                    wav_ram(0) <= s1_writedata(7 downto 4);
+                                    wav_ram(1) <= s1_writedata(3 downto 0);
+                                when "0001" => --      FF31 0000 1111 Samples 2 and 3
+                                    wav_ram(2) <= s1_writedata(7 downto 4);
+                                    wav_ram(3) <= s1_writedata(3 downto 0);
+                                when "0010" => --      FF32 0000 1111 Samples 4 and 5
+                                    wav_ram(4) <= s1_writedata(7 downto 4);
+                                    wav_ram(5) <= s1_writedata(3 downto 0);
+                                when "0011" => --      FF33 0000 1111 Samples 6 and 31
+                                    wav_ram(6) <= s1_writedata(7 downto 4);
+                                    wav_ram(7) <= s1_writedata(3 downto 0);
+                                when "0100" => --      FF34 0000 1111 Samples 8 and 31
+                                    wav_ram(8) <= s1_writedata(7 downto 4);
+                                    wav_ram(9) <= s1_writedata(3 downto 0);
+                                when "0101" => --      FF35 0000 1111 Samples 10 and 11
+                                    wav_ram(10) <= s1_writedata(7 downto 4);
+                                    wav_ram(11) <= s1_writedata(3 downto 0);
+                                when "0110" => --      FF36 0000 1111 Samples 12 and 13
+                                    wav_ram(12) <= s1_writedata(7 downto 4);
+                                    wav_ram(13) <= s1_writedata(3 downto 0);
+                                when "0111" => --      FF37 0000 1111 Samples 14 and 15
+                                    wav_ram(14) <= s1_writedata(7 downto 4);
+                                    wav_ram(15) <= s1_writedata(3 downto 0);
+                                when "1000" => --      FF38 0000 1111 Samples 16 and 17
+                                    wav_ram(16) <= s1_writedata(7 downto 4);
+                                    wav_ram(17) <= s1_writedata(3 downto 0);
+                                when "1001" => --      FF39 0000 1111 Samples 18 and 19
+                                    wav_ram(18) <= s1_writedata(7 downto 4);
+                                    wav_ram(19) <= s1_writedata(3 downto 0);
+                                when "1010" => --      FF3A 0000 1111 Samples 20 and 21
+                                    wav_ram(20) <= s1_writedata(7 downto 4);
+                                    wav_ram(21) <= s1_writedata(3 downto 0);
+                                when "1011" => --      FF3B 0000 1111 Samples 22 and 23
+                                    wav_ram(22) <= s1_writedata(7 downto 4);
+                                    wav_ram(23) <= s1_writedata(3 downto 0);
+                                when "1100" => --      FF3C 0000 1111 Samples 24 and 25
+                                    wav_ram(24) <= s1_writedata(7 downto 4);
+                                    wav_ram(25) <= s1_writedata(3 downto 0);
+                                when "1101" => --      FF3D 0000 1111 Samples 26 and 27
+                                    wav_ram(26) <= s1_writedata(7 downto 4);
+                                    wav_ram(27) <= s1_writedata(3 downto 0);
+                                when "1110" => --      FF3E 0000 1111 Samples 28 and 29
+                                    wav_ram(28) <= s1_writedata(7 downto 4);
+                                    wav_ram(29) <= s1_writedata(3 downto 0);
+                                when "1111" => --      FF3F 0000 1111 Samples 30 and 31
+                                    wav_ram(30) <= s1_writedata(7 downto 4);
+                                    wav_ram(31) <= s1_writedata(3 downto 0);
+                                end case;
+                            end if;
 
                         -- NR52 FF26 P--- NW21 Power control/status, Channel length statuses
                         when "0100110" => 
@@ -641,7 +653,7 @@ begin
     process (s1_addr, sq1_swper, sq1_swdir, sq1_swshift, sq1_duty, sq1_svol, sq1_envsgn, sq1_envper, sq1_lenchk,
         noi_playing, wav_playing, sq2_playing, sq1_playing, wav_enable, wav_volsh, wav_ram, wav_index, wav_access,
         sq2_duty, sq2_svol, sq2_envsgn, sq2_envper, sq2_lenchk, snd_enable, wav_lenchk, noi_svol, noi_envsgn, noi_envper,
-        noi_freqsh, noi_short, noi_div, noi_lenchk, ch_vol, ch_map, is_gbc, sq1_vol, sq2_vol, wav_wav, noi_vol)
+        noi_freqsh, noi_short, noi_div, noi_lenchk, ch_vol, ch_map, is_gbc, sq1_wav, sq2_wav, wav_wav, noi_wav)
         variable wave_index_read : std_logic_vector(3 downto 0);
     begin
         case s1_addr is
@@ -778,7 +790,7 @@ begin
 
     end process;
 
-    sound : process (clk, snd_enable, en_snd, en_len, en_env, en_sweep, wav_access, reset)
+    sound : process (clk, snd_enable, en_snd, en_len, en_env, en_sweep, wav_access, sq1_out, sq1_vol, sq2_out, sq2_vol, noi_vol, sq1_suppressed, sq2_suppressed, reset)
         constant duty_0          : std_logic_vector(0 to 7) := "00000001";
         constant duty_1          : std_logic_vector(0 to 7) := "10000001";
         constant duty_2          : std_logic_vector(0 to 7) := "10000111";


### PR DESCRIPTION
- synced the reset with the 4MHz clock, sometimes when resetting after running a game/demo in fast mode (8 MHz ) some peripherals (APU in my case) were off by one cycle

- This aligns the square channels (1 and 2) and implements it's timer quirk (fixes the super mario land ringing sound when finishing a level)

- sq1 and sq2 duty change waits for the current sample to finish (seems to fix some pops/crackling)

- two undocumented registers pcm12 and pcm34 were implemented (https://github.com/LIJI32/GBVisualizer now plays, and the samesuite tests can be used to further work on improving the APU)

- Writes to the wave table now follow the same logic as the reads (blargg's CGB sound tests now all pass)

the envelope restart improved considerably in mdfourier:
![DA__ALL_AVG_A-GBC-CG600872809_vs_gb-core-pcm12](https://user-images.githubusercontent.com/407195/88409869-77caf180-cdcd-11ea-8c5f-dd3b8ff4ad6d.png)

![DA__ALL_AVG_A-GBC-CG600872809_vs_pcm12-sq1-sq2-restartbov](https://user-images.githubusercontent.com/407195/88409896-80232c80-cdcd-11ea-8d77-b1e6c0aed7c3.png)

Still work to do 😄

