### PR TITLE
Change the Game Boy Color MGL setname to GBC

### DIFF
--- a/releases/Game Boy Color.mgl
+++ b/releases/Game Boy Color.mgl
@@ -1,4 +1,4 @@
 <mistergamedescription>
 	<rbf>_Console/Gameboy</rbf>
-	<setname>GameboyColor</setname>
+	<setname>GBC</setname>
 </mistergamedescription>


### PR DESCRIPTION
@theypsilon reached out and recommended we change the setname to "GBC" to avoid naming the mgl game directory all caps for consistency with the original "GAMEBOY" core capitalization.