### PR TITLE
Fix bug with sound panning.

### DIFF
--- a/rtl/gbc_snd.vhd
+++ b/rtl/gbc_snd.vhd
@@ -1683,12 +1683,10 @@ begin
 				when others => null;
 			end case;
 
-			if k < 4 then
-				if ch_map(k) = '1' then
+			if ch_map(k) = '1' then
+				if k < 4 then
 					snd_right_in := snd_right_in + dac_out(wav);
-				end if;
-			else
-				if ch_map(k - 4) = '1' then
+				else
 					snd_left_in  := snd_left_in + dac_out(wav);
 				end if;
 			end if;


### PR DESCRIPTION
Introduced a small bug in #235, where left and right audio channels were identical. Fixing that here.

This build fixes the problem. Thanks to @MP2E for also flagging the issue and providing a good test case.
[Gameboy_PR237_20230415.zip](https://github.com/MiSTer-devel/Gameboy_MiSTer/files/11239289/Gameboy_PR237_20230415.zip)
